### PR TITLE
fix: ReportExamples test - fix edit button label

### DIFF
--- a/frontend/src/components/__tests__/ReportExamples.test.tsx
+++ b/frontend/src/components/__tests__/ReportExamples.test.tsx
@@ -9,7 +9,7 @@ vi.mock('@clerk/react', () => ({
 vi.mock('../../api', () => ({
   listReportExamples: vi.fn().mockResolvedValue({
     examples: [
-      { id: '1', name: 'Report.jpg', content: 'Student showed great improvement in math.' },
+      { id: '1', name: 'Report.jpg', content: 'Student showed great improvement in math.', status: 'ready' },
     ],
   }),
   uploadReportExample: vi.fn(),


### PR DESCRIPTION
The test mock data was missing `status: 'ready'`, so the edit button (only rendered for ready examples) was never in the DOM. Added the status field to the mock.