### PR TITLE
feat: paste text notes with AI extraction

### DIFF
--- a/backend/ARCHITECTURE.md
+++ b/backend/ARCHITECTURE.md
@@ -39,6 +39,7 @@ Go HTTP backend for GradeBee, a teacher tool for managing student rosters, proce
 | DELETE | `/report-examples` | Yes | `handleDeleteReportExample` | Delete example report card |
 | PUT | `/report-examples/{id}` | Yes | `handleUpdateReportExample` | Update example report card |
 | POST | `/voice-notes/upload` | Yes | `handleUpload` | Upload audio to disk + dispatch job |
+| POST | `/text-notes/upload` | Yes | `handleTextNotesUpload` | Submit pasted text + dispatch extraction job |
 | POST | `/voice-notes/drive-import` | Yes | `handleDriveImport` | Download from Drive + dispatch job |
 | GET | `/google-token` | Yes | `handleGoogleToken` | Return Google OAuth token for Drive Picker |
 | GET | `/voice-notes/jobs` | Yes | `handleJobList` | List user's async upload jobs |

--- a/backend/handler.go
+++ b/backend/handler.go
@@ -266,6 +266,8 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 	// Voice note upload + Drive import
 	case path == "voice-notes/upload" && r.Method == http.MethodPost:
 		authHandler(handleUpload).ServeHTTP(rec, r)
+	case path == "text-notes/upload" && r.Method == http.MethodPost:
+		authHandler(handleTextNotesUpload).ServeHTTP(rec, r)
 	case path == "voice-notes/drive-import" && r.Method == http.MethodPost:
 		authHandler(handleDriveImport).ServeHTTP(rec, r)
 	case path == "drive-import-example" && r.Method == http.MethodPost:

--- a/backend/text_notes.go
+++ b/backend/text_notes.go
@@ -1,0 +1,83 @@
+// text_notes.go handles POST /text-notes/upload — accepts pasted text,
+// creates a voice_notes row (with no audio file), and dispatches a job
+// that skips transcription and goes straight to extraction.
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+const maxTextSize = 50 * 1024 // 50 KB
+
+type textNotesRequest struct {
+	Text string `json:"text"`
+}
+
+func handleTextNotesUpload(w http.ResponseWriter, r *http.Request) {
+	log := loggerFromRequest(r)
+
+	r.Body = http.MaxBytesReader(w, r.Body, int64(maxTextSize)+1024) // allow for JSON envelope
+	var req textNotesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		return
+	}
+
+	if req.Text == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "text is required"})
+		return
+	}
+	if len(req.Text) > maxTextSize {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "text too large (max 50KB)"})
+		return
+	}
+
+	userID, err := userIDFromRequest(r)
+	if err != nil {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	ctx := r.Context()
+
+	queue, err := serviceDeps.GetVoiceNoteQueue()
+	if err != nil {
+		log.Error("text-notes: queue unavailable", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "service unavailable"})
+		return
+	}
+
+	// Create a voice_notes row with no audio file.
+	repo := serviceDeps.GetVoiceNoteRepo()
+	upload, err := repo.Create(ctx, userID, "pasted-text", "")
+	if err != nil {
+		log.Error("text-notes: create record failed", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to save"})
+		return
+	}
+
+	err = publishOrCleanup(ctx, queue, VoiceNoteJob{
+		UserID:     userID,
+		UploadID:   upload.ID,
+		FileName:   "pasted-text",
+		Source:     "text",
+		Transcript: req.Text,
+		Status:     JobStatusQueued,
+		CreatedAt:  time.Now(),
+	},
+		func() { _ = repo.Delete(ctx, upload.ID) }, //nolint:errcheck // best-effort cleanup
+	)
+	if err != nil {
+		log.Error("text-notes: dispatch failed", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to process"})
+		return
+	}
+
+	log.Info("text-notes upload dispatched", "user_id", userID, "upload_id", upload.ID)
+	writeJSON(w, http.StatusOK, UploadResponse{
+		UploadID: upload.ID,
+		FileName: "pasted-text",
+	})
+}

--- a/backend/text_notes_test.go
+++ b/backend/text_notes_test.go
@@ -1,0 +1,131 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/clerk/clerk-sdk-go/v2"
+)
+
+func TestHandleTextNotesUpload_EmptyText(t *testing.T) {
+	body := `{"text":""}`
+	req := httptest.NewRequest(http.MethodPost, "/text-notes/upload", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	// Simulate authenticated user via Clerk claims.
+	rctx := clerk.ContextWithSessionClaims(req.Context(), &clerk.SessionClaims{
+		RegisteredClaims: clerk.RegisteredClaims{Subject: "user-1"},
+	})
+	req = req.WithContext(rctx)
+	rec := httptest.NewRecorder()
+
+	handleTextNotesUpload(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("empty text: got status %d, want 400", rec.Code)
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["error"] != "text is required" {
+		t.Errorf("empty text: got error %q, want %q", resp["error"], "text is required")
+	}
+}
+
+func TestHandleTextNotesUpload_TooLarge(t *testing.T) {
+	big := strings.Repeat("x", maxTextSize+1)
+	body, err := json.Marshal(textNotesRequest{Text: big})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/text-notes/upload", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rctx := clerk.ContextWithSessionClaims(req.Context(), &clerk.SessionClaims{
+		RegisteredClaims: clerk.RegisteredClaims{Subject: "user-1"},
+	})
+	req = req.WithContext(rctx)
+	rec := httptest.NewRecorder()
+
+	handleTextNotesUpload(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("too large: got status %d, want 400", rec.Code)
+	}
+}
+
+func TestHandleTextNotesUpload_InvalidJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/text-notes/upload", strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	rctx := clerk.ContextWithSessionClaims(req.Context(), &clerk.SessionClaims{
+		RegisteredClaims: clerk.RegisteredClaims{Subject: "user-1"},
+	})
+	req = req.WithContext(rctx)
+	rec := httptest.NewRecorder()
+
+	handleTextNotesUpload(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("invalid json: got status %d, want 400", rec.Code)
+	}
+}
+
+func TestHandleTextNotesUpload_HappyPath(t *testing.T) {
+	db := setupTestDB(t)
+	queue := newTestQueue(t)
+
+	oldDeps := serviceDeps
+	serviceDeps = &mockDepsAll{
+		db:             db,
+		voiceNoteRepo:  &VoiceNoteRepo{db: db},
+		voiceNoteQueue: queue,
+	}
+	t.Cleanup(func() { serviceDeps = oldDeps })
+
+	body, err := json.Marshal(textNotesRequest{Text: "Alice did great today"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/text-notes/upload", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rctx := clerk.ContextWithSessionClaims(req.Context(), &clerk.SessionClaims{
+		RegisteredClaims: clerk.RegisteredClaims{Subject: "user-1"},
+	})
+	req = req.WithContext(rctx)
+	rec := httptest.NewRecorder()
+
+	handleTextNotesUpload(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("happy path: got status %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp UploadResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.UploadID == 0 {
+		t.Error("expected non-zero upload ID")
+	}
+	if resp.FileName != "pasted-text" {
+		t.Errorf("got fileName %q, want %q", resp.FileName, "pasted-text")
+	}
+
+	// Verify the job was published with the transcript.
+	jobs, err := queue.ListJobs(t.Context(), "user-1")
+	if err != nil {
+		t.Fatalf("list jobs: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	if jobs[0].Transcript != "Alice did great today" {
+		t.Errorf("job transcript = %q, want %q", jobs[0].Transcript, "Alice did great today")
+	}
+	if jobs[0].Source != "text" {
+		t.Errorf("job source = %q, want %q", jobs[0].Source, "text")
+	}
+}

--- a/backend/voice_note_cleanup.go
+++ b/backend/voice_note_cleanup.go
@@ -36,9 +36,11 @@ func cleanProcessedVoiceNotes(ctx context.Context, repo *VoiceNoteRepo, retentio
 	}
 
 	for _, v := range stale {
-		if err := os.Remove(v.FilePath); err != nil && !os.IsNotExist(err) {
-			slog.Error("voice note cleanup: remove file", "path", v.FilePath, "error", err)
-			continue
+		if v.FilePath != "" {
+			if err := os.Remove(v.FilePath); err != nil && !os.IsNotExist(err) {
+				slog.Error("voice note cleanup: remove file", "path", v.FilePath, "error", err)
+				continue
+			}
 		}
 		if err := repo.Delete(ctx, v.ID); err != nil {
 			slog.Error("voice note cleanup: delete row", "id", v.ID, "error", err)

--- a/backend/voice_note_job.go
+++ b/backend/voice_note_job.go
@@ -27,18 +27,18 @@ type NoteLink struct {
 
 // VoiceNoteJob represents an async voice note processing job.
 type VoiceNoteJob struct {
-	UserID    string     `json:"userId"`
-	UploadID  int64      `json:"uploadId"`
-	FilePath  string     `json:"filePath"`
-	FileName  string     `json:"fileName"`
-	MimeType  string     `json:"mimeType"`
+	UserID     string     `json:"userId"`
+	UploadID   int64      `json:"uploadId"`
+	FilePath   string     `json:"filePath"`
+	FileName   string     `json:"fileName"`
+	MimeType   string     `json:"mimeType"`
 	Source     string     `json:"source"`
 	Transcript string     `json:"transcript,omitempty"`
-	Status    string     `json:"status"`
-	CreatedAt time.Time  `json:"createdAt"`
-	NoteLinks []NoteLink `json:"noteLinks,omitempty"`
-	Error     string     `json:"error,omitempty"`
-	FailedAt  *time.Time `json:"failedAt,omitempty"`
+	Status     string     `json:"status"`
+	CreatedAt  time.Time  `json:"createdAt"`
+	NoteLinks  []NoteLink `json:"noteLinks,omitempty"`
+	Error      string     `json:"error,omitempty"`
+	FailedAt   *time.Time `json:"failedAt,omitempty"`
 }
 
 // JobKey implements Keyed.

--- a/backend/voice_note_job.go
+++ b/backend/voice_note_job.go
@@ -32,7 +32,8 @@ type VoiceNoteJob struct {
 	FilePath  string     `json:"filePath"`
 	FileName  string     `json:"fileName"`
 	MimeType  string     `json:"mimeType"`
-	Source    string     `json:"source"`
+	Source     string     `json:"source"`
+	Transcript string     `json:"transcript,omitempty"`
 	Status    string     `json:"status"`
 	CreatedAt time.Time  `json:"createdAt"`
 	NoteLinks []NoteLink `json:"noteLinks,omitempty"`

--- a/backend/voice_note_process.go
+++ b/backend/voice_note_process.go
@@ -47,35 +47,42 @@ func processVoiceNote(ctx context.Context, d deps, q JobQueue[VoiceNoteJob], key
 		return fmt.Errorf("process voice note: %s: %w", step, err)
 	}
 
-	// --- Step 1: Transcribe ---
-	job.Status = JobStatusTranscribing
-	if err := q.UpdateJob(ctx, *job); err != nil {
-		return fail("update status to transcribing", err)
-	}
-
-	audioFile, err := os.Open(job.FilePath)
-	if err != nil {
-		return fail("open audio file", err)
-	}
-	defer audioFile.Close()
-
-	var whisperPrompt string
+	// --- Step 1: Transcribe (skip if text was pasted) ---
 	roster := d.GetRoster(ctx, userID)
-	names, err := roster.ClassNames(ctx)
-	if err != nil {
-		log.Warn("process voice note: could not read class names", "error", err)
-	} else if len(names) > 0 {
-		whisperPrompt = "Classes: " + strings.Join(names, ", ")
-	}
+	var transcript string
+	if job.Transcript != "" {
+		// Text input — skip transcription entirely.
+		transcript = job.Transcript
+		log.Info("process voice note: skipping transcription (text input)", "key", key)
+	} else {
+		job.Status = JobStatusTranscribing
+		if err := q.UpdateJob(ctx, *job); err != nil {
+			return fail("update status to transcribing", err)
+		}
 
-	transcriber, err := d.GetTranscriber()
-	if err != nil {
-		return fail("init transcriber", err)
-	}
+		audioFile, err := os.Open(job.FilePath)
+		if err != nil {
+			return fail("open audio file", err)
+		}
+		defer audioFile.Close()
 
-	transcript, err := transcriber.Transcribe(ctx, job.FileName, audioFile, whisperPrompt)
-	if err != nil {
-		return fail("transcribe", err)
+		var whisperPrompt string
+		names, err := roster.ClassNames(ctx)
+		if err != nil {
+			log.Warn("process voice note: could not read class names", "error", err)
+		} else if len(names) > 0 {
+			whisperPrompt = "Classes: " + strings.Join(names, ", ")
+		}
+
+		transcriber, err := d.GetTranscriber()
+		if err != nil {
+			return fail("init transcriber", err)
+		}
+
+		transcript, err = transcriber.Transcribe(ctx, job.FileName, audioFile, whisperPrompt)
+		if err != nil {
+			return fail("transcribe", err)
+		}
 	}
 
 	// --- Step 2: Extract ---

--- a/e2e/drive-setup.spec.ts
+++ b/e2e/drive-setup.spec.ts
@@ -11,7 +11,7 @@ test.describe('Authenticated app loads correctly', () => {
 
     // Storage state from global setup should make us appear signed in.
     await expect(page.getByTestId('audio-upload')).toBeVisible({ timeout: 15000 })
-    await expect(page.getByRole('heading', { name: 'Upload Audio' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Add Notes' })).toBeVisible()
   })
 
   test('shows class management UI', async ({ page }) => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -266,6 +266,24 @@ export async function uploadAudio(
   return body
 }
 
+export async function submitTextNotes(
+  text: string,
+  getToken: () => Promise<string | null>
+): Promise<{ uploadId: number; fileName: string }> {
+  const token = await getToken()
+  const resp = await fetch(`${apiUrl}/text-notes/upload`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ text }),
+  })
+  const body = await resp.json()
+  if (!resp.ok) throw new Error(body.error || 'Failed to submit text notes')
+  return body
+}
+
 // --- Report Examples ---
 
 export async function listReportExamples(

--- a/frontend/src/components/AudioUpload.tsx
+++ b/frontend/src/components/AudioUpload.tsx
@@ -332,7 +332,7 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
             transition={{ duration: 0.25 }}
           >
             <span className="upload-success-icon">✓</span>
-            Submitted! Processing in background.
+            {fileName === 'pasted-text' ? 'Submitted' : 'Uploaded'}! Processing in background.
           </motion.div>
         )}
       </AnimatePresence>

--- a/frontend/src/components/AudioUpload.tsx
+++ b/frontend/src/components/AudioUpload.tsx
@@ -1,7 +1,7 @@
 import { useAuth } from '@clerk/react'
 import { useRef, useState } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
-import { uploadAudio, getGoogleToken, importFromDrive } from '../api'
+import { uploadAudio, getGoogleToken, importFromDrive, submitTextNotes } from '../api'
 import { useDrivePicker, AUDIO_MIME_TYPES } from '../hooks/useDrivePicker'
 import { useMediaQuery } from '../hooks/useMediaQuery'
 
@@ -46,6 +46,18 @@ function DriveIcon() {
   )
 }
 
+function PasteIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+      <rect x="5" y="3" width="14" height="18" rx="2" stroke="#E8A317" strokeWidth="1.5" fill="none" />
+      <path d="M9 3V2a1 1 0 011-1h4a1 1 0 011 1v1" stroke="#E8A317" strokeWidth="1.5" strokeLinecap="round" />
+      <line x1="9" y1="9" x2="15" y2="9" stroke="#E8A317" strokeWidth="1.5" strokeLinecap="round" />
+      <line x1="9" y1="13" x2="15" y2="13" stroke="#E8A317" strokeWidth="1.5" strokeLinecap="round" />
+      <line x1="9" y1="17" x2="12" y2="17" stroke="#E8A317" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  )
+}
+
 export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => void }) {
   const { getToken } = useAuth()
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -54,6 +66,8 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
   const [error, setError] = useState<string>('')
   const [dragOver, setDragOver] = useState(false)
   const [showSuccess, setShowSuccess] = useState(false)
+  const [showPaste, setShowPaste] = useState(false)
+  const [pasteText, setPasteText] = useState('')
   const { openPicker } = useDrivePicker()
   const isMobile = useMediaQuery('(max-width: 640px)')
 
@@ -68,6 +82,8 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
   function onUploadComplete() {
     setStatus('idle')
     setShowSuccess(true)
+    setPasteText('')
+    setShowPaste(false)
     if (fileInputRef.current) fileInputRef.current.value = ''
     onUploadDone?.()
     setTimeout(() => setShowSuccess(false), SUCCESS_TOAST_MS)
@@ -113,6 +129,22 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
     }
   }
 
+  async function handlePasteSubmit() {
+    if (!pasteText.trim()) return
+    setError('')
+    setShowSuccess(false)
+    setFileName('pasted-text')
+
+    try {
+      setStatus('uploading')
+      await submitTextNotes(pasteText, getToken)
+      onUploadComplete()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong')
+      setStatus('error')
+    }
+  }
+
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
     if (file) processFile(file)
@@ -142,7 +174,7 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.35, delay: 0.15 }}
     >
-      <h2>Upload Audio</h2>
+      <h2>Add Notes</h2>
 
       <AnimatePresence mode="wait">
         {(status === 'idle' || status === 'error') && (
@@ -172,7 +204,16 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
                   <DriveIcon />
                   Add from Drive
                 </button>
-                <p className="hint">Accepted: mp3, mp4, m4a, wav, webm (max {MAX_SIZE_MB} MB)</p>
+                <button
+                  type="button"
+                  className="mobile-upload-btn btn-secondary"
+                  onClick={() => setShowPaste(!showPaste)}
+                  data-testid="paste-text-btn"
+                >
+                  <PasteIcon />
+                  Paste Text
+                </button>
+                <p className="hint">Accepted audio: mp3, mp4, m4a, wav, webm (max {MAX_SIZE_MB} MB)</p>
                 <input
                   ref={fileInputRef}
                   type="file"
@@ -204,7 +245,7 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
                     data-testid="file-input"
                   />
                 </div>
-                <div className="drive-import-row">
+                <div className="secondary-actions">
                   <button
                     type="button"
                     className="btn-secondary"
@@ -214,9 +255,53 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
                     <DriveIcon />
                     Add from Drive
                   </button>
+                  <button
+                    type="button"
+                    className="btn-secondary"
+                    onClick={() => setShowPaste(!showPaste)}
+                    data-testid="paste-text-btn"
+                  >
+                    <PasteIcon />
+                    Paste Text
+                  </button>
                 </div>
               </>
             )}
+
+            {/* Paste text area */}
+            <AnimatePresence>
+              {showPaste && (
+                <motion.div
+                  className="paste-area"
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: 1, height: 'auto' }}
+                  exit={{ opacity: 0, height: 0 }}
+                  transition={{ duration: 0.25 }}
+                  data-testid="paste-area"
+                >
+                  <textarea
+                    className="paste-textarea"
+                    placeholder="Paste your notes here... Include student names and dates — we'll sort them out."
+                    value={pasteText}
+                    onChange={e => setPasteText(e.target.value)}
+                    rows={6}
+                    data-testid="paste-textarea"
+                  />
+                  <div className="paste-actions">
+                    <p className="hint">Include student names and dates — we'll match them to your roster.</p>
+                    <button
+                      type="button"
+                      className="btn-primary"
+                      onClick={handlePasteSubmit}
+                      disabled={!pasteText.trim()}
+                      data-testid="paste-submit-btn"
+                    >
+                      Process Notes
+                    </button>
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
           </motion.div>
         )}
 
@@ -231,7 +316,7 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
             transition={{ duration: 0.25 }}
           >
             <HoneycombSpinner />
-            <p>Uploading <strong>{fileName}</strong>...</p>
+            <p>{fileName === 'pasted-text' ? 'Processing notes...' : <>Uploading <strong>{fileName}</strong>...</>}</p>
           </motion.div>
         )}
       </AnimatePresence>
@@ -247,7 +332,7 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
             transition={{ duration: 0.25 }}
           >
             <span className="upload-success-icon">✓</span>
-            Uploaded! Processing in background.
+            Submitted! Processing in background.
           </motion.div>
         )}
       </AnimatePresence>

--- a/frontend/src/components/ReportExamples.tsx
+++ b/frontend/src/components/ReportExamples.tsx
@@ -209,7 +209,7 @@ export default function ReportExamples() {
                 <p>Drop files here or click to upload<br/><span style={{ fontSize: '0.8rem', opacity: 0.6 }}>Text, PDF, or image files</span></p>
               )}
             </div>
-            <div className="drive-import-row" style={{ marginTop: '0.5rem' }}>
+            <div className="secondary-actions" style={{ marginTop: '0.5rem' }}>
               <button
                 type="button"
                 className="btn-secondary"

--- a/frontend/src/components/__tests__/AudioUpload.test.tsx
+++ b/frontend/src/components/__tests__/AudioUpload.test.tsx
@@ -1,15 +1,17 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const mockUploadAudio = vi.fn()
 const mockGetGoogleToken = vi.fn()
 const mockImportFromDrive = vi.fn()
+const mockSubmitTextNotes = vi.fn()
 
 vi.mock('../../api', () => ({
   uploadAudio: (...args: unknown[]) => mockUploadAudio(...args),
   getGoogleToken: (...args: unknown[]) => mockGetGoogleToken(...args),
   importFromDrive: (...args: unknown[]) => mockImportFromDrive(...args),
+  submitTextNotes: (...args: unknown[]) => mockSubmitTextNotes(...args),
 }))
 
 vi.mock('@clerk/react', () => ({
@@ -99,5 +101,55 @@ describe('AudioUpload', () => {
     })
     // These should not exist as API functions anymore
     expect(mockUploadAudio).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows paste textarea when Paste Text is clicked', async () => {
+    const { default: AudioUpload } = await import('../AudioUpload')
+    render(<AudioUpload />)
+
+    // Paste area should not be visible initially
+    expect(screen.queryByTestId('paste-area')).not.toBeInTheDocument()
+
+    // Click Paste Text button
+    await userEvent.click(screen.getByTestId('paste-text-btn'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('paste-textarea')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('paste-submit-btn')).toBeDisabled()
+  })
+
+  it('submits pasted text and shows success', async () => {
+    mockSubmitTextNotes.mockResolvedValue({ uploadId: 1, fileName: 'pasted-text' })
+
+    const { default: AudioUpload } = await import('../AudioUpload')
+    render(<AudioUpload />)
+
+    await userEvent.click(screen.getByTestId('paste-text-btn'))
+    fireEvent.change(screen.getByTestId('paste-textarea'), { target: { value: 'Alice did great today' } })
+
+    expect(screen.getByTestId('paste-submit-btn')).not.toBeDisabled()
+    await userEvent.click(screen.getByTestId('paste-submit-btn'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('upload-success')).toHaveTextContent(/Processing in background/)
+    })
+    expect(mockSubmitTextNotes).toHaveBeenCalledTimes(1)
+    expect(mockSubmitTextNotes.mock.calls[0][0]).toBe('Alice did great today')
+  })
+
+  it('shows error when paste submission fails', async () => {
+    mockSubmitTextNotes.mockRejectedValue(new Error('Extraction failed'))
+
+    const { default: AudioUpload } = await import('../AudioUpload')
+    render(<AudioUpload />)
+
+    await userEvent.click(screen.getByTestId('paste-text-btn'))
+    fireEvent.change(screen.getByTestId('paste-textarea'), { target: { value: 'Some notes' } })
+    await userEvent.click(screen.getByTestId('paste-submit-btn'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('upload-error')).toHaveTextContent('Extraction failed')
+    })
   })
 })

--- a/frontend/src/components/__tests__/AudioUpload.test.tsx
+++ b/frontend/src/components/__tests__/AudioUpload.test.tsx
@@ -33,7 +33,7 @@ describe('AudioUpload', () => {
     const { default: AudioUpload } = await import('../AudioUpload')
     render(<AudioUpload />)
     expect(screen.getByTestId('drop-zone')).toBeInTheDocument()
-    expect(screen.getByText('Upload Audio')).toBeInTheDocument()
+    expect(screen.getByText('Add Notes')).toBeInTheDocument()
   })
 
   it('rejects files over 25MB', async () => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -735,15 +735,70 @@ button:disabled {
   font-weight: 400;
 }
 
-.drive-import-row {
+.secondary-actions {
   display: flex;
   justify-content: center;
+  gap: 0.75rem;
   margin-top: 0.75rem;
 }
 
-.drive-import-row .btn-secondary {
+.secondary-actions .btn-secondary {
+  flex: 1;
+  max-width: 12rem;
   font-size: 0.9rem;
   padding: 0.55rem 1.1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+}
+
+.paste-area {
+  margin-top: 1rem;
+  overflow: hidden;
+}
+
+.paste-textarea {
+  width: 100%;
+  min-height: 8rem;
+  padding: 0.85rem 1rem;
+  border: 2px solid var(--comb);
+  border-radius: var(--radius);
+  background: var(--chalk);
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  color: var(--ink);
+  resize: vertical;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  box-sizing: border-box;
+}
+
+.paste-textarea:focus {
+  outline: none;
+  border-color: var(--honey);
+  box-shadow: 0 0 0 3px rgba(232, 163, 23, 0.15);
+}
+
+.paste-textarea::placeholder {
+  color: var(--ink-muted);
+}
+
+.paste-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 0.5rem;
+  gap: 1rem;
+}
+
+.paste-actions .hint {
+  font-size: 0.85rem;
+  color: var(--ink-muted);
+  margin: 0;
+}
+
+.paste-actions .btn-primary {
+  white-space: nowrap;
 }
 
 /* Upload progress / transcribing states */
@@ -885,6 +940,17 @@ button:disabled {
   font-size: 0.85rem;
   color: var(--ink-muted);
   text-align: center;
+}
+
+@media (max-width: 640px) {
+  .paste-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .paste-actions .hint {
+    text-align: center;
+  }
 }
 
 /* --- Responsive --- */


### PR DESCRIPTION
## What

Allow teachers to paste a block of text containing notes about multiple students, classes, and dates. The system extracts and creates individual per-student notes using the existing AI extraction pipeline (skipping transcription).

Also redesigns the "Add Notes" input section so audio upload and secondary actions (Drive import, paste text) feel unified.

## Changes

### Backend
- New `POST /text-notes/upload` endpoint accepting `{ "text": "..." }`
- Reuses voice note job queue — skips transcription step when transcript is pre-filled
- Added `Transcript` field to `VoiceNoteJob`
- Guards empty `FilePath` in voice note cleanup (text notes have no audio file)
- 50KB max text size limit

### Frontend
- Renamed "Upload Audio" → "Add Notes"
- Two equal secondary buttons below drop zone: "Add from Drive" + "Paste Text"
- Textarea slides open with animation when "Paste Text" is clicked
- Context-aware success message ("Uploaded!" vs "Submitted!")
- Mobile: paste text as third stacked button

### Tests
- `text_notes_test.go`: 4 backend tests (empty, too large, invalid JSON, happy path)
- `AudioUpload.test.tsx`: 3 frontend tests (show textarea, submit success, submit error)
- Updated e2e references for heading rename

## Plan
See `docs/plans/2026-04-10-paste-notes.md`