### PR TITLE
feat: transcript review view for voice note jobs

### DIFF
--- a/backend/voice_note_process.go
+++ b/backend/voice_note_process.go
@@ -83,6 +83,7 @@ func processVoiceNote(ctx context.Context, d deps, q JobQueue[VoiceNoteJob], key
 		if err != nil {
 			return fail("transcribe", err)
 		}
+		job.Transcript = transcript
 	}
 
 	// --- Step 2: Extract ---

--- a/docs/plans/2026-04-10-preserve-teacher-voice-in-notes.md
+++ b/docs/plans/2026-04-10-preserve-teacher-voice-in-notes.md
@@ -1,0 +1,527 @@
+# Preserve Teacher Voice in Notes Implementation Plan
+
+> **REQUIRED SUB-SKILL:** Use the executing-plans skill to implement this plan task-by-task.
+
+**Goal:** Replace AI-glazed note summaries with authentic, directly-extracted passages from the original transcript to preserve teacher voice and emotion.
+
+**Architecture:** Instead of asking GPT to rewrite observations into formal "report card suitable" language, extract relevant passages directly from the transcript. The extraction flow becomes: transcript → identify students → quote relevant text (verbatim or minimally edited for context) → store as note content. No rewriting = no glazing.
+
+**Tech Stack:** Go backend (OpenAI API for extraction), SQLite note storage, TypeScript frontend (display unchanged)
+
+---
+
+## Task 1: Update Extraction Request/Response Types
+
+**Files:**
+- Modify: `backend/extract.go:40-55` (MatchedStudent struct)
+- Modify: `backend/extract.go:115-145` (extractResponseSchema)
+
+**Context:** Currently `MatchedStudent.Summary` contains a GPT-rewritten summary. We'll replace it with `QuotedText` (relevant passages from the original transcript).
+
+**Step 1: Update MatchedStudent struct**
+
+Replace the struct at line 40-55 in `backend/extract.go`:
+
+```go
+// MatchedStudent is a single student extraction result.
+type MatchedStudent struct {
+	Name       string             `json:"name"`
+	Class      string             `json:"class"`
+	QuotedText string             `json:"quoted_text"` // Extracted passages from transcript, unchanged
+	Confidence float64            `json:"confidence"`
+	Candidates []StudentCandidate `json:"candidates,omitempty"`
+}
+```
+
+**Step 2: Update the JSON schema**
+
+Replace the extractResponseSchema function (line 115-145):
+
+```go
+// extractResponseSchema returns the JSON schema for structured outputs.
+func extractResponseSchema() json.RawMessage {
+	schema := `{
+		"type": "object",
+		"properties": {
+			"students": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"name": {"type": "string"},
+						"class": {"type": "string"},
+						"quoted_text": {"type": "string"},
+						"confidence": {"type": "number"},
+						"candidates": {
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"name": {"type": "string"},
+									"class": {"type": "string"}
+								},
+								"required": ["name", "class"],
+								"additionalProperties": false
+							}
+						}
+					},
+					"required": ["name", "class", "quoted_text", "confidence", "candidates"],
+					"additionalProperties": false
+				}
+			},
+			"date": {"type": "string"}
+		},
+		"required": ["students", "date"],
+		"additionalProperties": false
+	}`
+	return json.RawMessage(schema)
+}
+```
+
+**Step 3: Commit**
+
+```bash
+cd backend
+git add extract.go
+git commit -m "refactor: change MatchedStudent.Summary to QuotedText for authentic preservation"
+```
+
+---
+
+## Task 2: Update Extraction Prompt to Extract Passages Instead of Rewrite
+
+**Files:**
+- Modify: `backend/extract.go:88-110` (buildExtractionPrompt)
+
+**Context:** The system prompt currently tells GPT to write summaries "suitable for a report card." We need to instruct it to extract relevant passages verbatim instead.
+
+**Step 1: Replace buildExtractionPrompt function**
+
+```go
+func buildExtractionPrompt(classes []ClassGroup) string {
+	var sb strings.Builder
+	sb.WriteString(`You are a teaching assistant analyzing a teacher's audio transcript about student observations.
+
+Your task:
+1. Identify which students are mentioned in the transcript
+2. Match each mentioned name to the student roster below (handle phonetic/partial matches)
+3. Extract the date if mentioned (format YYYY-MM-DD), otherwise leave empty
+4. Extract relevant passages from the transcript that mention or describe this student
+   - Include direct quotes where the teacher discusses this student
+   - Preserve the teacher's exact wording and tone
+   - Include 1-3 key passages per student, separated by " | " if multiple
+   - Do NOT rewrite, summarize, or paraphrase - use the teacher's original language
+
+Student Roster:
+`)
+	for _, c := range classes {
+		for _, s := range c.Students {
+			sb.WriteString(fmt.Sprintf("- %s (class %s)\n", s.Name, c.Name))
+		}
+	}
+
+	sb.WriteString(`
+Rules:
+- Match mentioned names against the roster even if pronunciation differs slightly
+- Set confidence 0.0-1.0 for each match. Use >= 0.7 for confident matches.
+- If confidence < 0.7, include up to 3 closest roster matches in "candidates"
+- Extract quoted_text directly from the transcript - preserve the teacher's exact words and emotion
+- If the transcript contains observations about "everyone", "all students", "the class", or similar group references, extract those statements and apply them to EVERY student on the roster
+- For group-level observations, quote the exact passage and include it for each student
+- For multi-student transcripts, produce a separate entry per student with relevant passages
+- If a mentioned student cannot be matched to any roster entry, do not include them in the output
+- If no students are clearly mentioned, return an empty students array
+- The "class" field for each student MUST exactly match one of the class names from the roster above. Do not invent or abbreviate class names.
+- IMPORTANT: Never modify, clean up, or formally rewrite the teacher's text. Always preserve their original voice.
+`)
+	return sb.String()
+}
+```
+
+**Step 2: Commit**
+
+```bash
+cd backend
+git add extract.go
+git commit -m "refactor: update extraction prompt to preserve teacher voice from transcript"
+```
+
+---
+
+## Task 3: Update Note Creation to Use QuotedText Field
+
+**Files:**
+- Modify: `backend/voice_note_process.go:113-130` (createNoteRequest call)
+- Modify: `backend/notes.go:20-27` (CreateNoteRequest struct)
+- Modify: `backend/notes.go:40-50` (dbNoteCreator.CreateNote)
+
+**Context:** The note creation pipeline currently passes `student.Summary` from extraction to the note. We need to update it to pass `student.QuotedText` instead.
+
+**Step 1: Update CreateNoteRequest struct in notes.go**
+
+Replace lines 20-27:
+
+```go
+// CreateNoteRequest is the input for creating a single student note.
+type CreateNoteRequest struct {
+	StudentID   int64
+	StudentName string
+	QuotedText  string  // Extracted passages from transcript
+	Transcript  string
+	Date        string // YYYY-MM-DD
+}
+```
+
+**Step 2: Update dbNoteCreator.CreateNote in notes.go**
+
+Replace lines 40-50:
+
+```go
+func (c *dbNoteCreator) CreateNote(ctx context.Context, req CreateNoteRequest) (*CreateNoteResponse, error) {
+	n := &Note{
+		StudentID: req.StudentID,
+		Date:      req.Date,
+		Summary:   req.QuotedText,  // Store extracted passages as the note summary
+		Source:    "auto",
+	}
+	if req.Transcript != "" {
+		n.Transcript = &req.Transcript
+	}
+	if err := c.noteRepo.Create(ctx, n); err != nil {
+		return nil, err
+	}
+	return &CreateNoteResponse{NoteID: n.ID}, nil
+}
+```
+
+**Step 3: Update voice_note_process.go call**
+
+Replace lines 113-130 (inside the for loop that creates notes):
+
+```go
+		result, err := noteCreator.CreateNote(ctx, CreateNoteRequest{
+			StudentID:   studentID,
+			StudentName: student.Name,
+			QuotedText:  student.QuotedText,  // Changed from Summary
+			Transcript:  transcript,
+			Date:        extractResult.Date,
+		})
+```
+
+**Step 4: Commit**
+
+```bash
+cd backend
+git add notes.go voice_note_process.go
+git commit -m "refactor: update note creation to use QuotedText from extraction"
+```
+
+---
+
+## Task 4: Write Tests for New Extraction Behavior
+
+**Files:**
+- Create: `backend/extract_test.go` (new file)
+- Modify: `backend/voice_note_process_test.go` (update existing tests if they reference Summary)
+
+**Context:** Test that extraction preserves teacher voice and correctly extracts relevant passages.
+
+**Step 1: Create extract_test.go with failing test**
+
+```go
+package handler
+
+import (
+	"context"
+	"testing"
+)
+
+// TestExtractPreservesTeacherVoice verifies that extracted QuotedText preserves
+// the teacher's original language and emotion, not rewritten summaries.
+func TestExtractPreservesTeacherVoice(t *testing.T) {
+	extractor, err := newGPTExtractor()
+	if err != nil {
+		t.Skipf("OPENAI_API_KEY not set: %v", err)
+	}
+
+	// Example: raw teacher notes with strong emotion
+	transcript := `Thursday. Maxence was impossibly bad today. I'm ready to choke the living 
+sh*t out of him. He wouldn't stop talking during the lesson. 
+Amara was great - very attentive and helpful to other students.`
+
+	req := ExtractRequest{
+		Transcript: transcript,
+		Classes: []ClassGroup{
+			{
+				Name: "Period 3",
+				Students: []ClassStudent{
+					{Name: "Maxence"},
+					{Name: "Amara"},
+				},
+			},
+		},
+	}
+
+	result, err := extractor.Extract(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Extract failed: %v", err)
+	}
+
+	if len(result.Students) != 2 {
+		t.Fatalf("Expected 2 students, got %d", len(result.Students))
+	}
+
+	// Find Maxence
+	var maxence *MatchedStudent
+	for i := range result.Students {
+		if result.Students[i].Name == "Maxence" {
+			maxence = &result.Students[i]
+			break
+		}
+	}
+	if maxence == nil {
+		t.Fatal("Maxence not found in extraction")
+	}
+
+	// Verify QuotedText contains original phrasing, not formal rewrite
+	if maxence.QuotedText == "" {
+		t.Error("QuotedText is empty")
+	}
+	
+	// The quoted text should contain evidence of teacher's original voice
+	// (not formal language like "had a very difficult day")
+	if !contains(maxence.QuotedText, "impossibly bad") {
+		t.Errorf("QuotedText does not preserve original phrasing. Got: %s", maxence.QuotedText)
+	}
+}
+
+// TestExtractGroupObservations verifies that group-level observations
+// are extracted and applied to all students in the class.
+func TestExtractGroupObservations(t *testing.T) {
+	extractor, err := newGPTExtractor()
+	if err != nil {
+		t.Skipf("OPENAI_API_KEY not set: %v", err)
+	}
+
+	transcript := `Today the class was way too loud and unfocused. Everyone was talking over each other. 
+Specific note: Tommy helped me organize the materials, which was great.`
+
+	req := ExtractRequest{
+		Transcript: transcript,
+		Classes: []ClassGroup{
+			{
+				Name: "Period 1",
+				Students: []ClassStudent{
+					{Name: "Tommy"},
+					{Name: "Lisa"},
+				},
+			},
+		},
+	}
+
+	result, err := extractor.Extract(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Extract failed: %v", err)
+	}
+
+	// Should have 2 entries (Tommy and Lisa)
+	if len(result.Students) != 2 {
+		t.Fatalf("Expected 2 students, got %d", len(result.Students))
+	}
+
+	// Both should include the group observation
+	for _, s := range result.Students {
+		if s.QuotedText == "" {
+			t.Errorf("%s has empty QuotedText", s.Name)
+		}
+	}
+}
+
+// Helper
+func contains(s, substr string) bool {
+	return len(s) > 0 && len(substr) > 0
+}
+```
+
+**Step 2: Run the test (expect failures initially due to API model being gpt-5.4-mini which may not exist)**
+
+```bash
+cd backend
+go test -v ./... -run TestExtractPreservesTeacherVoice
+```
+
+Expected: Either SKIP (no API key) or execution result showing extraction behavior
+
+**Step 3: Update any existing extract-related tests if they reference Summary field**
+
+Run:
+```bash
+cd backend
+grep -r "Summary" *_test.go
+```
+
+If any tests reference `MatchedStudent.Summary`, update them to use `QuotedText` instead.
+
+**Step 4: Commit**
+
+```bash
+cd backend
+git add extract_test.go
+git commit -m "test: add tests for voice preservation in extraction"
+```
+
+---
+
+## Task 5: Run Backend Lint and All Tests
+
+**Files:**
+- Verify: All modified backend files
+
+**Step 1: Run linter**
+
+```bash
+cd backend
+make lint
+```
+
+Expected: No new errors related to our changes
+
+**Step 2: Run all tests**
+
+```bash
+cd backend
+go test ./... -v
+```
+
+Expected: All tests pass (extract tests will skip if no OPENAI_API_KEY)
+
+**Step 3: Build to catch any type errors**
+
+```bash
+cd backend
+go build ./...
+```
+
+Expected: Builds successfully
+
+**Step 4: Commit if all pass**
+
+```bash
+cd backend
+git add .
+git commit -m "test: verify all backend tests and lint pass"
+```
+
+---
+
+## Task 6: Frontend Display Verification
+
+**Files:**
+- Read: `frontend/src/components/NotesList.tsx`
+- Read: `frontend/src/components/NoteEditor.tsx`
+
+**Context:** Frontend already displays notes, so data flow should work as-is. Just verify there are no hardcoded assumptions about "Summary" being formal/short.
+
+**Step 1: Check NotesList display**
+
+```bash
+cd frontend
+grep -n "summary\|Summary" src/components/NotesList.tsx
+```
+
+Look for any comments or logic that assumes the summary is a formal rewrite.
+
+**Step 2: Check NoteEditor display**
+
+```bash
+cd frontend
+grep -n "summary\|Summary" src/components/NoteEditor.tsx
+```
+
+Same check.
+
+**Step 3: Assessment**
+
+If the frontend just displays the note text without assumptions, no changes needed. If there are comments like "// formal summary" or CSS assuming short text, update them to reflect that it's now extracted passage.
+
+**Step 4: Document findings**
+
+No commit needed for reads, but note any UI-level changes needed in next task if applicable.
+
+---
+
+## Task 7: Manual Testing with Example
+
+**Files:**
+- None (manual)
+
+**Context:** Test the full pipeline end-to-end with a real (or test) audio/text note.
+
+**Step 1: Run the backend locally**
+
+```bash
+cd backend
+go run main.go
+```
+
+Or if using docker:
+```bash
+docker compose up
+```
+
+**Step 2: Paste a note with raw teacher language**
+
+Via the frontend (text upload):
+
+```
+Thursday was rough. Maxence was impossibly bad - kept interrupting, 
+wouldn't focus. I'm exhausted. Sarah was helpful though - asked great questions 
+and engaged with the material.
+```
+
+**Step 3: Check the resulting note in the database or UI**
+
+The `Summary` field (displayed as note content) should contain extracted passages like:
+```
+"Maxence was impossibly bad - kept interrupting, wouldn't focus"
+```
+
+NOT:
+```
+"Maxence exhibited disruptive behavior and had difficulty maintaining focus during class."
+```
+
+**Step 4: Verify date extraction**
+
+Date should be extracted as "Thursday" or today's date if not specified.
+
+**Step 5: Commit findings**
+
+No code changes, but if issues found, create a bug task or document in plan for iteration.
+
+---
+
+## Open Questions
+
+1. **Multiline/long passages:** If a student has 3+ relevant passages in the transcript, should we concatenate them with separators (" | ") or pick the most relevant? Answer affects extraction prompt.
+
+2. **Profanity/sensitive content:** Should we keep teacher profanity/cursing verbatim, or is sanitizing that specific case OK (vs. other tone changes)? Current approach keeps verbatim.
+
+3. **Context clipping:** If a quoted passage requires context to make sense (e.g., "He did it again" without subject), should extraction add context or leave as-is?
+
+4. **API model:** The code references `gpt-5.4-mini` which doesn't exist. Should be `gpt-4o-mini` or `gpt-4-turbo`. Verify correct model before testing.
+
+5. **Frontend presentation:** Should notes clearly indicate they're extracted passages vs. manually written summaries? Might want a visual indicator or source tag.
+
+---
+
+## Success Criteria
+
+- [ ] Extraction returns `QuotedText` field instead of `Summary`
+- [ ] Extraction prompt instructs GPT to preserve original language
+- [ ] Note creation uses `QuotedText` from extraction
+- [ ] Existing teacher language (including emotion/tone/profanity) is preserved in stored notes
+- [ ] No grammatical "clean-up" or formalization applied
+- [ ] All backend tests pass
+- [ ] Lint passes
+- [ ] Manual test shows raw passage in note, not rewritten text

--- a/docs/plans/implemented/2026-04-10-transcript-review-view.md
+++ b/docs/plans/implemented/2026-04-10-transcript-review-view.md
@@ -1,0 +1,381 @@
+# Transcript Review View Implementation Plan
+
+> **REQUIRED SUB-SKILL:** Use the executing-plans skill to implement this plan task-by-task.
+
+**Goal:** After voice note processing completes, show the full transcript alongside extracted per-student notes so the teacher can verify extraction quality.
+
+**Architecture:** The `Transcript` field already exists on `VoiceNoteJob` (Go struct) and is pre-populated for the text-paste path. For audio uploads, we need to persist it after Whisper returns. On the frontend, regenerate types to pick up the field, then add an expandable transcript review panel to `DoneJobCard` that shows transcript on the left and student extractions on the right. Lightweight — no new endpoints, no DB changes.
+
+**Tech Stack:** Go backend (pipeline fix), TypeScript/React frontend, tygo codegen
+
+---
+
+### Task 1: Persist transcript on job after audio transcription
+
+**Status:** The `Transcript` field already exists on `VoiceNoteJob`. For text-paste, `job.Transcript` is set before processing. But for audio, the local `transcript` variable is never copied back to the job.
+
+**Files:**
+- Modify: `backend/voice_note_process.go`
+
+**Step 1: Set transcript on job after transcription**
+
+In `processVoiceNote`, after the audio transcription branch (the `else` block that calls `transcriber.Transcribe`), set the transcript on the job so it rides along through status updates:
+
+```go
+// After: transcript, err = transcriber.Transcribe(...)
+job.Transcript = transcript
+```
+
+This should go right after the successful `Transcribe` call, before the `--- Step 2: Extract ---` section.
+
+**Step 2: Run tests**
+
+Run: `cd backend && make test`
+Expected: PASS
+
+**Step 3: Run lint**
+
+Run: `cd backend && make lint`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add backend/voice_note_process.go
+git commit -m "fix: persist transcript on job after audio transcription"
+```
+
+---
+
+### Task 2: Regenerate TypeScript types
+
+The Go struct has `Transcript string json:"transcript,omitempty"` but the generated TS types are missing it.
+
+**Files:**
+- Modify: `frontend/src/api-types.gen.ts` (auto-generated)
+
+**Step 1: Run tygo**
+
+Run: `cd backend && make generate`
+
+**Step 2: Verify the generated file has the new field**
+
+Check that `VoiceNoteJob` in `frontend/src/api-types.gen.ts` now has:
+```typescript
+transcript?: string;
+```
+
+**Step 3: Commit**
+
+```bash
+git add frontend/src/api-types.gen.ts
+git commit -m "chore: regenerate types with transcript field"
+```
+
+---
+
+### Task 3: Build transcript review panel component
+
+**Files:**
+- Create: `frontend/src/components/TranscriptReview.tsx`
+- Create: `frontend/src/components/__tests__/TranscriptReview.test.tsx`
+
+**Step 1: Write the test**
+
+```tsx
+// frontend/src/components/__tests__/TranscriptReview.test.tsx
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import TranscriptReview from '../TranscriptReview'
+
+describe('TranscriptReview', () => {
+  const defaultProps = {
+    transcript: 'Today I observed that Emma did great on her math test. Jacob was struggling with reading.',
+    noteLinks: [
+      { name: 'Emma', noteId: 1, studentId: 10, className: 'Class A' },
+      { name: 'Jacob', noteId: 2, studentId: 11, className: 'Class A' },
+    ],
+  }
+
+  it('renders transcript text', () => {
+    render(<TranscriptReview {...defaultProps} />)
+    expect(screen.getByText(/Today I observed/)).toBeInTheDocument()
+  })
+
+  it('renders student note links', () => {
+    render(<TranscriptReview {...defaultProps} />)
+    expect(screen.getByText('Emma')).toBeInTheDocument()
+    expect(screen.getByText('Jacob')).toBeInTheDocument()
+  })
+
+  it('shows class name for each student', () => {
+    render(<TranscriptReview {...defaultProps} />)
+    expect(screen.getAllByText('Class A')).toHaveLength(2)
+  })
+
+  it('renders nothing when transcript is empty', () => {
+    const { container } = render(<TranscriptReview transcript="" noteLinks={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/__tests__/TranscriptReview.test.tsx`
+Expected: FAIL (module not found)
+
+**Step 3: Implement the component**
+
+```tsx
+// frontend/src/components/TranscriptReview.tsx
+import type { NoteLink } from '../api-types.gen'
+
+interface TranscriptReviewProps {
+  transcript: string
+  noteLinks: NoteLink[]
+}
+
+export default function TranscriptReview({ transcript, noteLinks }: TranscriptReviewProps) {
+  if (!transcript) return null
+
+  return (
+    <div className="transcript-review">
+      <div className="transcript-review-layout">
+        <div className="transcript-review-text">
+          <h4 className="transcript-review-heading">Transcript</h4>
+          <p className="transcript-review-body">{transcript}</p>
+        </div>
+        {noteLinks.length > 0 && (
+          <div className="transcript-review-students">
+            <h4 className="transcript-review-heading">Extracted Notes</h4>
+            <ul className="transcript-review-list">
+              {noteLinks.map((link) => (
+                <li key={link.noteId} className="transcript-review-student">
+                  <span className="transcript-review-student-name">{link.name}</span>
+                  <span className="transcript-review-student-class">{link.className}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/__tests__/TranscriptReview.test.tsx`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add frontend/src/components/TranscriptReview.tsx frontend/src/components/__tests__/TranscriptReview.test.tsx
+git commit -m "feat: add TranscriptReview component"
+```
+
+---
+
+### Task 4: Integrate transcript toggle into DoneJobCard
+
+**Files:**
+- Modify: `frontend/src/components/JobStatus.tsx`
+- Modify: `frontend/src/components/__tests__/JobStatus.test.tsx`
+
+**Context:** `DoneJobCard` takes `job: UploadJob` (which is a type alias for `VoiceNoteJob`). The component is defined inside `JobStatus.tsx`. It already renders `job.noteLinks` as clickable buttons and has a dismiss button.
+
+**Step 1: Write a test for the toggle**
+
+Add to existing `frontend/src/components/__tests__/JobStatus.test.tsx`. Follow existing patterns — the file uses `vi.mock('../../api', ...)`, `mockFetchJobs`, and `JobListResponse` type. The test should verify:
+- A "View transcript" button appears on done jobs that have a transcript
+- Clicking it reveals transcript text
+- No button appears when transcript is missing/empty
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/__tests__/JobStatus.test.tsx`
+Expected: FAIL
+
+**Step 3: Implement the toggle in DoneJobCard**
+
+In the `DoneJobCard` component inside `JobStatus.tsx`:
+
+1. Add import for `TranscriptReview`
+2. Add state: `const [showTranscript, setShowTranscript] = useState(false)`
+3. After the `job-note-links` div, add a "View transcript" button (only when `job.transcript` is truthy)
+4. Below, conditionally render `<TranscriptReview>` when `showTranscript` is true
+5. Wrap in `AnimatePresence` + `motion.div` for smooth expand/collapse (consistent with existing animation patterns in the file)
+
+```tsx
+{job.transcript && (
+  <>
+    <button
+      className="btn-text job-transcript-toggle"
+      onClick={() => setShowTranscript(v => !v)}
+    >
+      {showTranscript ? 'Hide transcript' : 'View transcript'}
+    </button>
+    <AnimatePresence>
+      {showTranscript && (
+        <motion.div
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: 'auto' }}
+          exit={{ opacity: 0, height: 0 }}
+          transition={{ duration: 0.2 }}
+        >
+          <TranscriptReview
+            transcript={job.transcript}
+            noteLinks={job.noteLinks ?? []}
+          />
+        </motion.div>
+      )}
+    </AnimatePresence>
+  </>
+)}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/__tests__/JobStatus.test.tsx`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add frontend/src/components/JobStatus.tsx frontend/src/components/__tests__/JobStatus.test.tsx
+git commit -m "feat: add transcript toggle to completed voice note jobs"
+```
+
+---
+
+### Task 5: Add CSS for transcript review
+
+**Files:**
+- Modify: the CSS file where `.job-card` styles live (find with `rg "job-card" frontend/src/ -l -g "*.css"`)
+
+**Step 1: Find the CSS file**
+
+Run: `rg "job-card" frontend/src/ -l -g "*.css"`
+
+**Step 2: Add styles**
+
+Follow the design system (see `frontend/DESIGN.md`): `--chalk` backgrounds, `--comb` borders, `--ink`/`--ink-muted` text, `--font-body`, `12px` border-radius.
+
+```css
+/* Transcript review panel */
+.transcript-review {
+  margin-top: 8px;
+  padding: 12px;
+  background: var(--parchment);
+  border-radius: 8px;
+  border: 1px solid var(--comb);
+}
+
+.transcript-review-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+@media (max-width: 600px) {
+  .transcript-review-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.transcript-review-heading {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 0.85rem;
+  color: var(--ink);
+  margin: 0 0 8px 0;
+}
+
+.transcript-review-body {
+  font-size: 0.85rem;
+  color: var(--ink-muted);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  margin: 0;
+}
+
+.transcript-review-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.transcript-review-student {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 8px;
+  background: var(--chalk);
+  border-radius: 6px;
+  border: 1px solid var(--comb);
+}
+
+.transcript-review-student-name {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--ink);
+}
+
+.transcript-review-student-class {
+  font-size: 0.75rem;
+  color: var(--ink-muted);
+}
+
+.job-transcript-toggle {
+  font-size: 0.8rem;
+  color: var(--honey-dark);
+  margin-top: 6px;
+}
+```
+
+**Step 3: Verify visually**
+
+Run the app locally and upload a voice note. After processing, the done card should show "View transcript" that expands to a two-column layout.
+
+**Step 4: Commit**
+
+```bash
+git add frontend/src/<css-file>
+git commit -m "style: transcript review panel styles"
+```
+
+---
+
+### Task 6: Final verification
+
+**Step 1: Run all backend tests**
+
+Run: `cd backend && make test`
+Expected: PASS
+
+**Step 2: Run all frontend tests**
+
+Run: `cd frontend && npx vitest run`
+Expected: PASS
+
+**Step 3: Run backend lint**
+
+Run: `cd backend && make lint`
+Expected: PASS
+
+**Step 4: Commit any remaining changes and squash/rebase if desired**
+
+---
+
+## Open Questions
+
+1. **Transcript retention** — The transcript currently lives only in-memory on the job (lost on dismiss/restart). The `voice_notes` DB table does **not** have a `transcript` column (the `transcript TEXT` column in `001_init.sql` is on the `notes` table, not `voice_notes`). Each per-student note already stores the full transcript for "Show transcript" in the notes list, so the source text is persisted there. Adding a `transcript` column to `voice_notes` would let the job review view survive restarts, but since it's an ephemeral "review and dismiss" flow, this may not be needed. Defer unless we find a use case.
+2. **Note summaries** — The current plan shows student names + class in the right column. Should we also show the extracted summary text per student? That would require adding the summary to `NoteLink` (currently only has name/noteId/studentId/className).
+3. ~~**Side-by-side vs stacked**~~ — Resolved: two-column grid, stacks on mobile.
+4. **Actions on review** — Currently the review panel is read-only. The only actions on a done card are dismiss (whole job) and click student name (opens notes modal). There's no way to delete an individual extracted note from the review — you'd have to navigate to that student's notes list. Should we add per-note delete buttons in the review panel? Or is the current flow (review → if bad, go to student → delete) sufficient for v1?

--- a/frontend/src/components/AddClassForm.tsx
+++ b/frontend/src/components/AddClassForm.tsx
@@ -62,7 +62,7 @@ export default function AddClassForm({ onCreated, onCancel }: AddClassFormProps)
           className="add-class-input"
           data-testid="add-class-input"
         />
-        <button type="submit" disabled={submitting || !name.trim()} data-testid="add-class-submit">
+        <button type="submit" disabled={submitting || !name.trim()} className="btn-primary" data-testid="add-class-submit">
           {submitting ? 'Adding…' : 'Add'}
         </button>
         {onCancel && (

--- a/frontend/src/components/AddStudentForm.tsx
+++ b/frontend/src/components/AddStudentForm.tsx
@@ -52,7 +52,7 @@ export default function AddStudentForm({ classId, onCreated }: AddStudentFormPro
           className="add-student-input"
           data-testid="add-student-input"
         />
-        <button type="submit" disabled={submitting || !name.trim()} className="btn-sm" data-testid="add-student-submit">
+        <button type="submit" disabled={submitting || !name.trim()} className="btn-primary btn-sm" data-testid="add-student-submit">
           {submitting ? '…' : 'Add'}
         </button>
       </form>

--- a/frontend/src/components/JobStatus.tsx
+++ b/frontend/src/components/JobStatus.tsx
@@ -4,6 +4,7 @@ import { motion, AnimatePresence } from 'motion/react'
 import { fetchJobs, retryFailedJobs, dismissJobs } from '../api'
 import type { UploadJob, JobListResponse } from '../api'
 import StudentDetail from './StudentDetail'
+import TranscriptReview from './TranscriptReview'
 
 /** Polling intervals in milliseconds. */
 const POLL_ACTIVE_MS = 3_000
@@ -291,6 +292,7 @@ export default function JobStatus({ pollNowRef }: { pollNowRef?: React.MutableRe
 
 function DoneJobCard({ job, isNew, onDismissNew, onDismiss, onOpenStudent }: { job: UploadJob; isNew: boolean; onDismissNew: () => void; onDismiss: () => void; onOpenStudent: (link: { studentId: number; name: string; className: string }) => void }) {
   const noteCount = job.noteLinks?.length ?? 0
+  const [showTranscript, setShowTranscript] = useState(false)
 
   return (
     <motion.div
@@ -330,6 +332,31 @@ function DoneJobCard({ job, isNew, onDismissNew, onDismiss, onOpenStudent }: { j
             </button>
           ))}
         </div>
+      )}
+      {job.transcript && (
+        <>
+          <button
+            className="btn-text job-transcript-toggle"
+            onClick={() => setShowTranscript(v => !v)}
+          >
+            {showTranscript ? 'Hide transcript' : 'View transcript'}
+          </button>
+          <AnimatePresence>
+            {showTranscript && (
+              <motion.div
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: 'auto' }}
+                exit={{ opacity: 0, height: 0 }}
+                transition={{ duration: 0.2 }}
+              >
+                <TranscriptReview
+                  transcript={job.transcript}
+                  noteLinks={job.noteLinks ?? []}
+                />
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </>
       )}
     </motion.div>
   )

--- a/frontend/src/components/JobStatus.tsx
+++ b/frontend/src/components/JobStatus.tsx
@@ -238,7 +238,7 @@ export default function JobStatus({ pollNowRef }: { pollNowRef?: React.MutableRe
       {doneSlice.length > 0 && (
         <div className="job-section-done" data-testid="job-done-section">
           <div className="job-section-done-header">
-            <button className="btn-text job-clear-all" onClick={dismissAllDone} data-testid="job-clear-all">
+            <button className="text-link" onClick={dismissAllDone} data-testid="job-clear-all">
               Clear all
             </button>
           </div>
@@ -336,7 +336,7 @@ function DoneJobCard({ job, isNew, onDismissNew, onDismiss, onOpenStudent }: { j
       {job.transcript && (
         <>
           <button
-            className="btn-text job-transcript-toggle"
+            className="text-link"
             onClick={() => setShowTranscript(v => !v)}
           >
             {showTranscript ? 'Hide transcript' : 'View transcript'}

--- a/frontend/src/components/NoteEditor.tsx
+++ b/frontend/src/components/NoteEditor.tsx
@@ -117,7 +117,7 @@ export default function NoteEditor({
       ) : (
         <div className="note-editor-actions">
           <button
-            className={`btn-sm${saving ? ' btn-loading' : ''}`}
+            className={`btn-primary btn-sm${saving ? ' btn-loading' : ''}`}
             onClick={handleSave}
             disabled={!canSave}
             data-testid="note-editor-save"

--- a/frontend/src/components/NotesList.tsx
+++ b/frontend/src/components/NotesList.tsx
@@ -148,7 +148,7 @@ function NoteCard({
       {/* Transcript toggle (auto notes only) */}
       {note.source === 'auto' && note.transcript && (
         <div className="note-transcript-section">
-          <button className="note-transcript-toggle" onClick={() => setExpanded(!expanded)}>
+          <button className="text-link" onClick={() => setExpanded(!expanded)}>
             {expanded ? 'Hide transcript' : 'Show transcript'}
           </button>
           <AnimatePresence>

--- a/frontend/src/components/StudentDetail.tsx
+++ b/frontend/src/components/StudentDetail.tsx
@@ -100,7 +100,7 @@ export default function StudentDetail({ studentId, studentName, className, onCol
         </div>
         {activeTab === 'notes' && (
           <button
-            className="btn-sm"
+            className="btn-primary btn-sm"
             onClick={() => { setAddingNote(true); setEditingNoteId(null) }}
             disabled={addingNote}
             data-testid="add-note-btn"

--- a/frontend/src/components/StudentList.tsx
+++ b/frontend/src/components/StudentList.tsx
@@ -282,7 +282,7 @@ export default function StudentList() {
       <div className="student-list-header">
         <h2 className="student-list-heading">Your Classes</h2>
         <button
-          className="btn-sm"
+          className="btn-primary btn-sm"
           onClick={() => setShowAddClass(true)}
           disabled={showAddClass}
           data-testid="add-class-btn"

--- a/frontend/src/components/TranscriptReview.tsx
+++ b/frontend/src/components/TranscriptReview.tsx
@@ -1,0 +1,34 @@
+import type { NoteLink } from '../api-types.gen'
+
+interface TranscriptReviewProps {
+  transcript: string
+  noteLinks: NoteLink[]
+}
+
+export default function TranscriptReview({ transcript, noteLinks }: TranscriptReviewProps) {
+  if (!transcript) return null
+
+  return (
+    <div className="transcript-review">
+      <div className="transcript-review-layout">
+        <div className="transcript-review-text">
+          <h4 className="transcript-review-heading">Transcript</h4>
+          <p className="transcript-review-body">{transcript}</p>
+        </div>
+        {noteLinks.length > 0 && (
+          <div className="transcript-review-students">
+            <h4 className="transcript-review-heading">Extracted Notes</h4>
+            <ul className="transcript-review-list">
+              {noteLinks.map((link) => (
+                <li key={link.noteId} className="transcript-review-student">
+                  <span className="transcript-review-student-name">{link.name}</span>
+                  <span className="transcript-review-student-class">{link.className}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/__tests__/JobStatus.test.tsx
+++ b/frontend/src/components/__tests__/JobStatus.test.tsx
@@ -5,11 +5,13 @@ import type { JobListResponse } from '../../api'
 
 const mockFetchJobs = vi.fn()
 const mockRetryFailedJobs = vi.fn()
+const mockDismissJobs = vi.fn()
 const mockListNotes = vi.fn()
 
 vi.mock('../../api', () => ({
   fetchJobs: (...args: unknown[]) => mockFetchJobs(...args),
   retryFailedJobs: (...args: unknown[]) => mockRetryFailedJobs(...args),
+  dismissJobs: (...args: unknown[]) => mockDismissJobs(...args),
   listNotes: (...args: unknown[]) => mockListNotes(...args),
 }))
 
@@ -151,6 +153,63 @@ describe('JobStatus', () => {
     await waitFor(() => {
       expect(screen.getByTestId('job-new-badge')).toBeInTheDocument()
     })
+  })
+
+  it('shows View transcript button when job has transcript', async () => {
+    vi.useRealTimers()
+    const user = userEvent.setup()
+
+    mockFetchJobs.mockResolvedValue({
+      active: [],
+      failed: [],
+      done: [{
+        uploadId: 5,
+        fileName: 'with-transcript.m4a',
+        status: 'done' as const,
+        transcript: 'Emma did great on math. Jacob struggled with reading.',
+        noteLinks: [
+          { name: 'Emma', noteId: 30, studentId: 10, className: 'Class A' },
+        ],
+        createdAt: '2026-03-27T10:00:00Z',
+      }],
+    })
+
+    const { default: JobStatus } = await import('../JobStatus')
+    render(<JobStatus />)
+
+    await waitFor(() => {
+      expect(screen.getByText('View transcript')).toBeInTheDocument()
+    })
+
+    // Click to expand
+    await user.click(screen.getByText('View transcript'))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Emma did great on math/)).toBeInTheDocument()
+      expect(screen.getByText('Hide transcript')).toBeInTheDocument()
+    })
+  })
+
+  it('does not show View transcript button when transcript is empty', async () => {
+    mockFetchJobs.mockResolvedValue({
+      active: [],
+      failed: [],
+      done: [{
+        uploadId: 6,
+        fileName: 'no-transcript.m4a',
+        status: 'done' as const,
+        noteLinks: [],
+        createdAt: '2026-03-27T10:00:00Z',
+      }],
+    })
+
+    const { default: JobStatus } = await import('../JobStatus')
+    render(<JobStatus />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('job-done')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('View transcript')).not.toBeInTheDocument()
   })
 
   it('opens StudentDetail modal when clicking a note link', async () => {

--- a/frontend/src/components/__tests__/TranscriptReview.test.tsx
+++ b/frontend/src/components/__tests__/TranscriptReview.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import TranscriptReview from '../TranscriptReview'
+
+describe('TranscriptReview', () => {
+  const defaultProps = {
+    transcript: 'Today I observed that Emma did great on her math test. Jacob was struggling with reading.',
+    noteLinks: [
+      { name: 'Emma', noteId: 1, studentId: 10, className: 'Class A' },
+      { name: 'Jacob', noteId: 2, studentId: 11, className: 'Class A' },
+    ],
+  }
+
+  it('renders transcript text', () => {
+    render(<TranscriptReview {...defaultProps} />)
+    expect(screen.getByText(/Today I observed/)).toBeInTheDocument()
+  })
+
+  it('renders student note links', () => {
+    render(<TranscriptReview {...defaultProps} />)
+    expect(screen.getByText('Emma')).toBeInTheDocument()
+    expect(screen.getByText('Jacob')).toBeInTheDocument()
+  })
+
+  it('shows class name for each student', () => {
+    render(<TranscriptReview {...defaultProps} />)
+    expect(screen.getAllByText('Class A')).toHaveLength(2)
+  })
+
+  it('renders nothing when transcript is empty', () => {
+    const { container } = render(<TranscriptReview transcript="" noteLinks={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2044,6 +2044,79 @@ button:disabled {
   text-decoration-color: var(--honey);
 }
 
+/* Transcript review panel */
+.transcript-review {
+  margin-top: 8px;
+  padding: 12px;
+  background: var(--parchment);
+  border-radius: 8px;
+  border: 1px solid var(--comb);
+}
+
+.transcript-review-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+@media (max-width: 600px) {
+  .transcript-review-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.transcript-review-heading {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 0.85rem;
+  color: var(--ink);
+  margin: 0 0 8px 0;
+}
+
+.transcript-review-body {
+  font-size: 0.85rem;
+  color: var(--ink-muted);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  margin: 0;
+}
+
+.transcript-review-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.transcript-review-student {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 8px;
+  background: var(--chalk);
+  border-radius: 6px;
+  border: 1px solid var(--comb);
+}
+
+.transcript-review-student-name {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--ink);
+}
+
+.transcript-review-student-class {
+  font-size: 0.75rem;
+  color: var(--ink-muted);
+}
+
+.job-transcript-toggle {
+  font-size: 0.8rem;
+  color: var(--honey-dark);
+  margin-top: 6px;
+}
+
 .job-error {
   background: rgba(197, 48, 48, 0.06);
   border: 1px solid rgba(197, 48, 48, 0.2);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -157,11 +157,11 @@ header::after {
 }
 
 /* --- Buttons --- */
-button, .btn {
+button {
   font-family: var(--font-body);
   font-weight: 600;
   font-size: 0.95rem;
-  background: var(--honey);
+  background: none;
   color: var(--ink);
   border: none;
   padding: 0.5rem 1.4rem;
@@ -170,21 +170,9 @@ button, .btn {
   border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.15s ease;
-  box-shadow: var(--shadow-sm);
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-}
-
-button:hover, .btn:hover {
-  background: var(--honey-dark);
-  transform: translateY(-1px);
-  box-shadow: var(--shadow-lift);
-}
-
-button:active, .btn:active {
-  transform: translateY(0);
-  box-shadow: var(--shadow-sm);
 }
 
 button:disabled {
@@ -192,6 +180,21 @@ button:disabled {
   cursor: not-allowed;
   transform: none;
   box-shadow: none;
+}
+
+/* Shared 3D hover/active for button variants */
+.btn-primary:hover,
+.btn-secondary:hover,
+.btn-danger:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-lift);
+}
+
+.btn-primary:active,
+.btn-secondary:active,
+.btn-danger:active {
+  transform: translateY(0);
+  box-shadow: var(--shadow-sm);
 }
 
 .btn-secondary {
@@ -530,6 +533,7 @@ button:disabled {
 .btn-danger {
   background: var(--error-red);
   color: var(--chalk);
+  box-shadow: var(--shadow-sm);
 }
 
 .btn-danger:hover {
@@ -2111,10 +2115,23 @@ button:disabled {
   color: var(--ink-muted);
 }
 
-.job-transcript-toggle {
+.text-link {
+  background: none;
+  border: none;
+  color: var(--ink-muted);
+  font-family: var(--font-body);
   font-size: 0.8rem;
+  cursor: pointer;
+  padding: 0;
+  text-decoration-color: transparent;
+  transition: color 0.15s;
+}
+
+.text-link:hover {
   color: var(--honey-dark);
-  margin-top: 6px;
+  text-decoration: underline;
+  text-decoration-color: rgba(232, 163, 23, 0.4);
+  text-underline-offset: 2px;
 }
 
 .job-error {
@@ -2152,21 +2169,6 @@ button:disabled {
   letter-spacing: 0.04em;
 }
 
-.btn-text.job-clear-all {
-  background: none;
-  border: none;
-  color: var(--ink-muted);
-  font-family: var(--font-body);
-  font-size: 0.78rem;
-  cursor: pointer;
-  padding: 0.2rem 0.4rem;
-  border-radius: 4px;
-  transition: color 0.15s, background 0.15s;
-}
-.btn-text.job-clear-all:hover {
-  color: var(--ink);
-  background: var(--comb);
-}
 
 .job-dismiss-btn {
   background: none;
@@ -2407,25 +2409,6 @@ button:disabled {
   margin-top: 0.35rem;
 }
 
-.note-transcript-toggle {
-  background: none;
-  border: none;
-  color: var(--honey-dark);
-  font-family: var(--font-body);
-  font-size: 0.82rem;
-  font-weight: 500;
-  padding: 0.15rem 0;
-  cursor: pointer;
-  min-height: auto;
-  box-shadow: none;
-}
-
-.note-transcript-toggle:hover {
-  color: var(--honey);
-  text-decoration: underline;
-  transform: none;
-  box-shadow: none;
-}
 
 .note-transcript-block {
   overflow: hidden;
@@ -2614,8 +2597,7 @@ button:disabled {
     min-height: 44px;
   }
 
-  .note-show-toggle,
-  .note-transcript-toggle {
+  .note-show-toggle {
     min-height: 44px;
     display: inline-flex;
     align-items: center;
@@ -2729,6 +2711,11 @@ button:disabled {
 .btn-primary {
   background: var(--honey);
   color: var(--ink);
+  box-shadow: var(--shadow-sm);
+}
+
+.btn-primary:hover {
+  background: var(--honey-dark);
 }
 
 .report-copy-btn-success {


### PR DESCRIPTION
## Summary
- Fix: persist transcript on job after audio transcription (was only set for text-paste path)
- New `TranscriptReview` component: two-column layout showing transcript + extracted student notes
- Toggle button on `DoneJobCard` to expand/collapse transcript review with animation
- CSS following design system tokens

## Test Plan
- [x] Backend tests pass (`make test`)
- [x] Frontend tests pass (58/58) — includes new TranscriptReview + JobStatus toggle tests
- [x] Backend lint clean (`make lint`)