### PR TITLE
feat: multi-select audio file upload

### DIFF
--- a/docs/plans/2026-04-13-multi-select-review-fixes.md
+++ b/docs/plans/2026-04-13-multi-select-review-fixes.md
@@ -1,0 +1,57 @@
+# Address Code Review Feedback — Multi-Select Upload
+
+## Goal
+Fix issues identified in code review of `feat/multi-select-upload`.
+
+## Changes
+
+### 1. Extract shared batch upload helper (Important #1)
+**File**: `frontend/src/components/AudioUpload.tsx`
+
+Extract a helper function used by both `processFiles` and `handleDriveImport`:
+
+```ts
+async function runBatchUpload(
+  items: { name: string; upload: () => Promise<unknown> }[],
+  onProgress: (index: number, name: string) => void
+): Promise<{ succeeded: number; failed: string[]; lastError: string | null }>
+```
+
+Both callers build the `items` array, call `runBatchUpload`, then handle the result with shared post-loop logic (set error/success state). The post-loop state updates are similar enough to also extract — evaluate during implementation.
+
+### 2. Fix picker `enableFeature` double-call (Important #2)
+**File**: `frontend/src/hooks/useDrivePicker.ts`
+
+Break the builder chain into a `let builder = ...` variable. Call `.enableFeature(NAV_HIDDEN)` once, then conditionally `builder.enableFeature(MULTISELECT_ENABLED)` only when `multiSelect` is true.
+
+### 3. Guard `picked[0]` in ReportExamples (Important #3)
+**File**: `frontend/src/components/ReportExamples.tsx`
+
+Change:
+```ts
+if (!picked) return
+```
+to:
+```ts
+if (!picked || picked.length === 0) return
+```
+
+### 4. Fix duplicate key on failedFiles list (Important #4)
+**File**: `frontend/src/components/AudioUpload.tsx`
+
+Change `key={f}` → `key={i}` (use index from `.map((f, i) => ...)`).
+
+### 5. Replace inline style on error `<ul>` (Suggestion #5)
+**File**: `frontend/src/components/AudioUpload.tsx`
+
+Add a CSS class (e.g., `upload-error-list`) instead of inline `style={{ marginTop, paddingLeft }}`.
+
+### 6. Pass plural title to Drive picker (Suggestion #6)
+**File**: `frontend/src/components/AudioUpload.tsx`
+
+In `handleDriveImport`, add `title: 'Select audio files'` to the `openPicker` options.
+
+### 7. Add test for multi-file oversized rejection (Suggestion #7)
+**File**: `frontend/src/components/__tests__/AudioUpload.test.tsx`
+
+New test: select 2 files where 1 exceeds 25 MB → both rejected, error message shown, `uploadAudio` never called.

--- a/frontend/src/components/AudioUpload.tsx
+++ b/frontend/src/components/AudioUpload.tsx
@@ -14,6 +14,27 @@ const MAX_SIZE_BYTES = MAX_SIZE_MB * 1024 * 1024
 /** How long to show the success toast before resetting to idle. */
 const SUCCESS_TOAST_MS = 3000
 
+async function runBatchUpload(
+  items: { name: string; upload: () => Promise<unknown> }[],
+  onProgress: (index: number, name: string) => void
+): Promise<{ succeeded: number; failed: string[]; lastError: string | null }> {
+  const failed: string[] = []
+  let succeeded = 0
+  let lastError: string | null = null
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]
+    onProgress(i + 1, item.name)
+    try {
+      await item.upload()
+      succeeded++
+    } catch (err) {
+      failed.push(item.name)
+      lastError = err instanceof Error ? err.message : 'Something went wrong'
+    }
+  }
+  return { succeeded, failed, lastError }
+}
+
 function MicIcon() {
   return (
     <svg className="drop-zone-icon" width="40" height="40" viewBox="0 0 40 40" fill="none">
@@ -64,6 +85,10 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
   const [status, setStatus] = useState<UploadStatus>('idle')
   const [fileName, setFileName] = useState<string>('')
   const [error, setError] = useState<string>('')
+  const [uploadIndex, setUploadIndex] = useState(0)
+  const [uploadTotal, setUploadTotal] = useState(0)
+  const [failedFiles, setFailedFiles] = useState<string[]>([])
+  const [successCount, setSuccessCount] = useState(0)
   const [dragOver, setDragOver] = useState(false)
   const [showSuccess, setShowSuccess] = useState(false)
   const [showPaste, setShowPaste] = useState(false)
@@ -86,12 +111,15 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
     setFileName('')
     setError('')
     setShowSuccess(false)
+    setFailedFiles([])
+    setSuccessCount(0)
     if (fileInputRef.current) fileInputRef.current.value = ''
   }
 
-  function onUploadComplete() {
+  function onUploadComplete(count: number) {
     setStatus('idle')
     setShowSuccess(true)
+    setSuccessCount(count)
     setPasteText('')
     setShowPaste(false)
     if (fileInputRef.current) fileInputRef.current.value = ''
@@ -99,24 +127,42 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
     setTimeout(() => setShowSuccess(false), SUCCESS_TOAST_MS)
   }
 
-  async function processFile(file: File) {
-    if (file.size > MAX_SIZE_BYTES) {
-      setError(`File too large (${(file.size / 1024 / 1024).toFixed(1)} MB). Max ${MAX_SIZE_MB} MB.`)
+  async function processFiles(files: File[]) {
+    const oversized = files.filter(f => f.size > MAX_SIZE_BYTES)
+    if (oversized.length > 0) {
+      setError(
+        oversized.length === 1
+          ? `File too large (${(oversized[0].size / 1024 / 1024).toFixed(1)} MB). Max ${MAX_SIZE_MB} MB.`
+          : `${oversized.length} files exceed the ${MAX_SIZE_MB} MB limit.`
+      )
       setStatus('error')
       return
     }
 
-    setFileName(file.name)
     setError('')
     setShowSuccess(false)
+    setFailedFiles([])
+    setUploadTotal(files.length)
 
-    try {
-      setStatus('uploading')
-      await uploadAudio(file, getToken)
-      onUploadComplete()
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Something went wrong')
+    setStatus('uploading')
+    const { succeeded, failed, lastError } = await runBatchUpload(
+      files.map(file => ({ name: file.name, upload: () => uploadAudio(file, getToken) })),
+      (index, name) => { setUploadIndex(index); setFileName(name) }
+    )
+
+    if (failed.length > 0) {
+      setFailedFiles(failed)
       setStatus('error')
+      if (files.length === 1) {
+        setError(lastError ?? 'Something went wrong')
+      } else if (succeeded > 0) {
+        setError(`${succeeded} file${succeeded > 1 ? 's' : ''} uploaded. ${failed.length} failed:`)
+        onUploadDone?.()
+      } else {
+        setError(`All ${files.length} files failed to upload:`)
+      }
+    } else {
+      onUploadComplete(succeeded)
     }
   }
 
@@ -126,13 +172,28 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
 
     try {
       const { accessToken } = await getGoogleToken(getToken)
-      const picked = await openPicker(accessToken, { mimeTypes: AUDIO_MIME_TYPES })
-      if (!picked) return
+      const picked = await openPicker(accessToken, { mimeTypes: AUDIO_MIME_TYPES, multiSelect: true, title: 'Select audio files' })
+      if (!picked || picked.length === 0) return
 
-      setFileName(picked.name)
+      setUploadTotal(picked.length)
       setStatus('uploading')
-      await importFromDrive(picked.id, picked.name, getToken)
-      onUploadComplete()
+      const { succeeded, failed } = await runBatchUpload(
+        picked.map(item => ({ name: item.name, upload: () => importFromDrive(item.id, item.name, getToken) })),
+        (index, name) => { setUploadIndex(index); setFileName(name) }
+      )
+
+      if (failed.length > 0) {
+        setFailedFiles(failed)
+        setStatus('error')
+        if (succeeded > 0) {
+          setError(`${succeeded} file${succeeded > 1 ? 's' : ''} uploaded. ${failed.length} failed:`)
+          onUploadDone?.()
+        } else {
+          setError(`All ${picked.length} files failed to upload:`)
+        }
+      } else {
+        onUploadComplete(succeeded)
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Something went wrong')
       setStatus('error')
@@ -148,7 +209,7 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
     try {
       setStatus('uploading')
       await submitTextNotes(pasteText, getToken)
-      onUploadComplete()
+      onUploadComplete(1)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Something went wrong')
       setStatus('error')
@@ -156,15 +217,15 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
   }
 
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0]
-    if (file) processFile(file)
+    const files = Array.from(e.target.files ?? [])
+    if (files.length > 0) processFiles(files)
   }
 
   function handleDrop(e: React.DragEvent) {
     e.preventDefault()
     setDragOver(false)
-    const file = e.dataTransfer.files?.[0]
-    if (file) processFile(file)
+    const files = Array.from(e.dataTransfer.files ?? [])
+    if (files.length > 0) processFiles(files)
   }
 
   function handleDragOver(e: React.DragEvent) {
@@ -203,7 +264,7 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
                   onClick={() => fileInputRef.current?.click()}
                   data-testid="mobile-file-btn"
                 >
-                  🎙️ Choose Audio File
+                  🎙️ Choose Audio Files
                 </button>
                 <button
                   type="button"
@@ -223,12 +284,13 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
                   <PasteIcon />
                   Paste Text
                 </button>
-                <p className="hint">Accepted audio: mp3, mp4, m4a, wav, webm (max {MAX_SIZE_MB} MB)</p>
+                <p className="hint">Accepted audio: mp3, mp4, m4a, wav, webm (max {MAX_SIZE_MB} MB each)</p>
                 <input
                   ref={fileInputRef}
                   type="file"
                   accept={ACCEPTED_FORMATS}
                   onChange={handleFileChange}
+                  multiple
                   style={{ display: 'none' }}
                   data-testid="file-input"
                 />
@@ -244,13 +306,14 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
                   data-testid="drop-zone"
                 >
                   <MicIcon />
-                  <p>Drag & drop an audio file here, or click to browse</p>
-                  <p className="hint">Accepted: mp3, mp4, m4a, wav, webm (max {MAX_SIZE_MB} MB)</p>
+                  <p>Drag & drop audio files here, or click to browse</p>
+                  <p className="hint">Accepted: mp3, mp4, m4a, wav, webm (max {MAX_SIZE_MB} MB each)</p>
                   <input
                     ref={fileInputRef}
                     type="file"
                     accept={ACCEPTED_FORMATS}
                     onChange={handleFileChange}
+                    multiple
                     style={{ display: 'none' }}
                     data-testid="file-input"
                   />
@@ -326,7 +389,11 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
             transition={{ duration: 0.25 }}
           >
             <HoneycombSpinner />
-            <p>{fileName === 'pasted-text' ? 'Processing notes...' : <>Uploading <strong>{fileName}</strong>...</>}</p>
+            <p>{fileName === 'pasted-text'
+              ? 'Processing notes...'
+              : uploadTotal > 1
+                ? <>Uploading <strong>{uploadIndex}/{uploadTotal}</strong>: {fileName}...</>
+                : <>Uploading <strong>{fileName}</strong>...</>}</p>
           </motion.div>
         )}
       </AnimatePresence>
@@ -342,7 +409,11 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
             transition={{ duration: 0.25 }}
           >
             <span className="upload-success-icon">✓</span>
-            {fileName === 'pasted-text' ? 'Submitted' : 'Uploaded'}! Processing in background.
+            {fileName === 'pasted-text'
+              ? 'Submitted'
+              : successCount > 1
+                ? `${successCount} files uploaded`
+                : 'Uploaded'}! Processing in background.
           </motion.div>
         )}
       </AnimatePresence>
@@ -350,6 +421,11 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
       {status === 'error' && (
         <div className="upload-error" data-testid="upload-error">
           <p>{error}</p>
+          {failedFiles.length > 0 && (
+            <ul className="upload-error-list">
+              {failedFiles.map((f, i) => <li key={i}>{f}</li>)}
+            </ul>
+          )}
           <button className="btn-secondary" onClick={reset} style={{ marginTop: '0.5rem' }}>
             Try again
           </button>

--- a/frontend/src/components/ReportExamples.tsx
+++ b/frontend/src/components/ReportExamples.tsx
@@ -110,9 +110,9 @@ export default function ReportExamples() {
         mimeTypes: REPORT_MIME_TYPES,
         title: 'Select a report card',
       })
-      if (!picked) return
+      if (!picked || picked.length === 0) return
       setDriveImporting(true)
-      await importExampleFromDrive(picked.id, picked.name, getToken)
+      await importExampleFromDrive(picked[0].id, picked[0].name, getToken)
       await load()
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Drive import failed')

--- a/frontend/src/components/__tests__/AudioUpload.test.tsx
+++ b/frontend/src/components/__tests__/AudioUpload.test.tsx
@@ -20,6 +20,7 @@ vi.mock('@clerk/react', () => ({
 
 vi.mock('../../hooks/useDrivePicker', () => ({
   useDrivePicker: () => ({ openPicker: vi.fn().mockResolvedValue(null) }),
+  AUDIO_MIME_TYPES: 'audio/mpeg',
 }))
 
 vi.mock('../../hooks/useMediaQuery', () => ({
@@ -167,5 +168,60 @@ describe('AudioUpload', () => {
     await waitFor(() => {
       expect(document.activeElement).toBe(screen.getByTestId('paste-textarea'))
     })
+  })
+
+  it('uploads multiple files sequentially and shows success count', async () => {
+    mockUploadAudio.mockResolvedValue({ uploadId: 1 })
+
+    const { default: AudioUpload } = await import('../AudioUpload')
+    render(<AudioUpload />)
+
+    const file1 = new File(['audio'], 'a.mp3', { type: 'audio/mpeg' })
+    const file2 = new File(['audio'], 'b.mp3', { type: 'audio/mpeg' })
+    const input = screen.getByTestId('file-input') as HTMLInputElement
+    await userEvent.upload(input, [file1, file2])
+
+    await waitFor(() => {
+      expect(screen.getByTestId('upload-success')).toHaveTextContent('2 files uploaded')
+    })
+    expect(mockUploadAudio).toHaveBeenCalledTimes(2)
+  })
+
+  it('shows partial failure summary when some files fail', async () => {
+    mockUploadAudio
+      .mockResolvedValueOnce({ uploadId: 1 })
+      .mockRejectedValueOnce(new Error('Server error'))
+
+    const { default: AudioUpload } = await import('../AudioUpload')
+    render(<AudioUpload />)
+
+    const file1 = new File(['audio'], 'ok.mp3', { type: 'audio/mpeg' })
+    const file2 = new File(['audio'], 'fail.mp3', { type: 'audio/mpeg' })
+    const input = screen.getByTestId('file-input') as HTMLInputElement
+    await userEvent.upload(input, [file1, file2])
+
+    await waitFor(() => {
+      const errorEl = screen.getByTestId('upload-error')
+      expect(errorEl).toHaveTextContent('1 file uploaded')
+      expect(errorEl).toHaveTextContent('fail.mp3')
+    })
+    expect(mockUploadAudio).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects all files when any file exceeds 25MB', async () => {
+    const { default: AudioUpload } = await import('../AudioUpload')
+    render(<AudioUpload />)
+
+    const okFile = new File(['audio'], 'ok.mp3', { type: 'audio/mpeg' })
+    const bigFile = new File(['x'.repeat(100)], 'big.mp3', { type: 'audio/mpeg' })
+    Object.defineProperty(bigFile, 'size', { value: 26 * 1024 * 1024 })
+
+    const input = screen.getByTestId('file-input') as HTMLInputElement
+    await userEvent.upload(input, [okFile, bigFile])
+
+    await waitFor(() => {
+      expect(screen.getByTestId('upload-error')).toHaveTextContent(/too large|exceed the 25 MB limit/)
+    })
+    expect(mockUploadAudio).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/hooks/useDrivePicker.ts
+++ b/frontend/src/hooks/useDrivePicker.ts
@@ -83,12 +83,13 @@ export function useDrivePicker() {
   const openPicker = useCallback(
     async (
       accessToken: string,
-      options?: { mimeTypes?: string; title?: string }
-    ): Promise<PickerResult | null> => {
+      options?: { mimeTypes?: string; title?: string; multiSelect?: boolean }
+    ): Promise<PickerResult[] | null> => {
       await loadPickerApi()
 
       const mimeTypes = options?.mimeTypes ?? AUDIO_MIME_TYPES
       const title = options?.title ?? 'Select an audio file'
+      const multiSelect = options?.multiSelect ?? false
 
       return new Promise((resolve) => {
         const view = new window.google.picker.PickerBuilder()
@@ -106,10 +107,16 @@ export function useDrivePicker() {
           )
           .setOAuthToken(accessToken)
           .enableFeature(window.google.picker.Feature.NAV_HIDDEN)
+
+        if (multiSelect) {
+          view.enableFeature((window.google.picker.Feature as unknown as Record<string, string>).MULTISELECT_ENABLED)
+        }
+
+        view
           .setTitle(title)
           .setCallback((data: PickerCallbackData) => {
-            if (data.action === window.google.picker.Action.PICKED && data.docs?.[0]) {
-              resolve({ id: data.docs[0].id, name: data.docs[0].name })
+            if (data.action === window.google.picker.Action.PICKED && data.docs?.length) {
+              resolve(data.docs.map(doc => ({ id: doc.id, name: doc.name })))
             } else if (data.action === window.google.picker.Action.CANCEL) {
               resolve(null)
             }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -881,6 +881,11 @@ button:active,
   margin-top: 0.75rem;
 }
 
+.upload-error-list {
+  margin-top: 0.25rem;
+  padding-left: 1.25rem;
+}
+
 /* Upload done */
 .upload-done {
   background: var(--chalk);


### PR DESCRIPTION
## Summary
Support selecting and uploading multiple audio files at once (local files and Google Drive).

## Changes
- **Multi-file local upload**: `multiple` attribute on file inputs, sequential upload with progress ("Uploading 2/3: filename...")
- **Partial failure handling**: continues uploading remaining files, shows error summary listing failed files
- **Drive picker multi-select**: new `multiSelect` option on `openPicker`, enabled for audio notes
- **Upfront validation**: all file sizes checked before any uploads begin
- **UI copy**: updated to plural ("audio files", "Select audio files", "max 25 MB each")

## Testing
- Added tests for multi-file upload success, partial failure, and oversized rejection
- All 64 tests pass

## Plan
See `docs/plans/2026-04-13-multi-select-audio-upload.md`