### PR TITLE
feat: inline error design pattern (#21)

### DIFF
--- a/backend/ARCHITECTURE.md
+++ b/backend/ARCHITECTURE.md
@@ -260,7 +260,7 @@ All CRUD endpoints verify resource ownership:
 | `repo_report.go` | `ReportRepo` — CRUD for reports |
 | `repo_example.go` | `ReportExampleRepo` — CRUD for report examples |
 | `repo_voice_note.go` | `VoiceNoteRepo` — CRUD for voice_notes, `MarkProcessed`, `ListStale` |
-| `repo_errors.go` | `ErrNotFound`, `ErrDuplicate`, `isDuplicateErr` |
+| `repo_errors.go` | `ErrNotFound`, `ErrDuplicate`, `isDuplicateErr`; `ErrDuplicateAlias` (carries `ConflictStudentName` for alias 409 responses) |
 | `students.go` | GET /students, class/student CRUD handlers, `classGroup`/`student` types |
 | `aliases.go` | GET/POST/DELETE /students/{id}/aliases — alias CRUD handlers |
 | `roster.go` | `Roster` interface + `dbRoster` — DB-backed roster reads |
@@ -302,7 +302,12 @@ When changing Go structs with `json` tags, regenerate types and commit the updat
 
 ## Error Handling
 
-`apiError` struct (`google.go`) carries HTTP status, machine-readable code, and human message. Handlers check `errors.As(err, &apiError)` and call `writeAPIError`. All responses are JSON.
+`apiError` struct (`google.go`) carries HTTP status, machine-readable code, human message, and an optional `Details map[string]string` field for structured context (e.g. `conflictStudentName` on alias collision). Handlers check `errors.As(err, &apiError)` and call `writeAPIError`. All responses are JSON.
+
+Repo-level errors:
+- `ErrNotFound` — entity not found
+- `ErrDuplicate` — generic unique constraint violation (used by class/student/note repos)
+- `*ErrDuplicateAlias` — alias-specific conflict that carries the canonical name of the student who owns the conflicting alias, so the handler can include it in the 409 `details` field
 
 ## Observability / Sentry
 

--- a/backend/aliases.go
+++ b/backend/aliases.go
@@ -81,8 +81,18 @@ func handleAddAlias(w http.ResponseWriter, r *http.Request) {
 
 	a, err := serviceDeps.GetStudentRepo().AddAlias(r.Context(), studentID, strings.TrimSpace(req.Alias))
 	if err != nil {
-		if errors.Is(err, ErrDuplicate) {
-			writeJSON(w, http.StatusConflict, map[string]string{"error": "alias already in use in this class"})
+		var dupErr *ErrDuplicateAlias
+		if errors.As(err, &dupErr) {
+			details := map[string]string{}
+			if dupErr.ConflictStudentName != "" {
+				details["conflictStudentName"] = dupErr.ConflictStudentName
+			}
+			writeAPIError(w, r, &apiError{
+				Status:  http.StatusConflict,
+				Code:    "alias_conflict",
+				Message: "Alias already in use in this class.",
+				Details: details,
+			})
 			return
 		}
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})

--- a/backend/aliases_test.go
+++ b/backend/aliases_test.go
@@ -1,0 +1,98 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/clerk/clerk-sdk-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleAddAlias_Conflict asserts that POST /students/{id}/aliases returns
+// HTTP 409 with error code "alias_conflict" and details.conflictStudentName
+// when the alias collides with an existing student or alias in the same class.
+func TestHandleAddAlias_Conflict(t *testing.T) {
+	db := setupTestDB(t)
+	studentRepo := &StudentRepo{db: db}
+	classRepo := &ClassRepo{db: db}
+	ctx := t.Context()
+
+	c, err := classRepo.Create(ctx, "user1", "Math", "")
+	require.NoError(t, err)
+	s1, err := studentRepo.Create(ctx, c.ID, "Alexander")
+	require.NoError(t, err)
+	_, err = studentRepo.Create(ctx, c.ID, "Katie")
+	require.NoError(t, err)
+
+	origDeps := serviceDeps
+	defer func() { serviceDeps = origDeps }()
+	serviceDeps = &mockDepsAll{classRepo: classRepo, studentRepo: studentRepo}
+
+	body, err := json.Marshal(map[string]string{"alias": "Katie"})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost,
+		fmt.Sprintf("/students/%d/aliases", s1.ID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	reqCtx := clerk.ContextWithSessionClaims(req.Context(), &clerk.SessionClaims{
+		RegisteredClaims: clerk.RegisteredClaims{Subject: "user1"},
+	})
+	req = req.WithContext(reqCtx)
+	rec := httptest.NewRecorder()
+
+	handleAddAlias(rec, req)
+
+	require.Equal(t, http.StatusConflict, rec.Code, "body: %s", rec.Body.String())
+
+	var resp struct {
+		Error   string            `json:"error"`
+		Message string            `json:"message"`
+		Details map[string]string `json:"details"`
+	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "alias_conflict", resp.Error)
+	assert.NotEmpty(t, resp.Message)
+	assert.Equal(t, "Katie", resp.Details["conflictStudentName"])
+}
+
+// TestHandleAddAlias_Success asserts that POST /students/{id}/aliases returns
+// HTTP 201 with the created alias on success.
+func TestHandleAddAlias_Success(t *testing.T) {
+	db := setupTestDB(t)
+	studentRepo := &StudentRepo{db: db}
+	classRepo := &ClassRepo{db: db}
+	ctx := t.Context()
+
+	c, err := classRepo.Create(ctx, "user1", "Math", "")
+	require.NoError(t, err)
+	s, err := studentRepo.Create(ctx, c.ID, "Alexander")
+	require.NoError(t, err)
+
+	origDeps := serviceDeps
+	defer func() { serviceDeps = origDeps }()
+	serviceDeps = &mockDepsAll{classRepo: classRepo, studentRepo: studentRepo}
+
+	body, err := json.Marshal(map[string]string{"alias": "Alex"})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost,
+		fmt.Sprintf("/students/%d/aliases", s.ID), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	reqCtx := clerk.ContextWithSessionClaims(req.Context(), &clerk.SessionClaims{
+		RegisteredClaims: clerk.RegisteredClaims{Subject: "user1"},
+	})
+	req = req.WithContext(reqCtx)
+	rec := httptest.NewRecorder()
+
+	handleAddAlias(rec, req)
+
+	require.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body.String())
+
+	var resp AliasResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "Alex", resp.Alias)
+	assert.Equal(t, s.ID, resp.StudentID)
+}

--- a/backend/google.go
+++ b/backend/google.go
@@ -17,8 +17,9 @@ import (
 type apiError struct {
 	Status  int
 	Err     error
-	Code    string // machine-readable error code, e.g. "no_spreadsheet"
-	Message string // human-readable message
+	Code    string            // machine-readable error code, e.g. "no_spreadsheet"
+	Message string            // human-readable message
+	Details map[string]string // optional structured details (forward-compat)
 }
 
 func (e *apiError) Error() string {
@@ -36,17 +37,25 @@ func writeAPIError(w http.ResponseWriter, r *http.Request, err *apiError) {
 	}
 	log.Warn("api error", "status", err.Status, "code", err.Code, "message", err.Message, "error", err.Err)
 
-	resp := map[string]string{}
+	type errorResponse struct {
+		Error   string            `json:"error"`
+		Message string            `json:"message,omitempty"`
+		Details map[string]string `json:"details,omitempty"`
+	}
+	resp := errorResponse{}
 	switch {
 	case err.Code != "":
-		resp["error"] = err.Code
+		resp.Error = err.Code
 	case err.Err != nil:
-		resp["error"] = err.Err.Error()
+		resp.Error = err.Err.Error()
 	default:
-		resp["error"] = "unknown error"
+		resp.Error = "unknown error"
 	}
 	if err.Message != "" {
-		resp["message"] = err.Message
+		resp.Message = err.Message
+	}
+	if len(err.Details) > 0 {
+		resp.Details = err.Details
 	}
 	writeJSON(w, err.Status, resp)
 }

--- a/backend/repo_errors.go
+++ b/backend/repo_errors.go
@@ -14,6 +14,22 @@ var (
 	ErrDuplicate = errors.New("duplicate")
 )
 
+// ErrDuplicateAlias is returned by AddAlias when the alias collides with an
+// existing student name or alias in the same class. ConflictStudentName holds
+// the canonical name of the student who owns the conflicting value, so the
+// handler can include it in the 409 response.
+type ErrDuplicateAlias struct {
+	ConflictStudentName string
+}
+
+func (e *ErrDuplicateAlias) Error() string { return "alias already in use in this class" }
+
+// Is satisfies errors.Is for target *ErrDuplicateAlias.
+func (e *ErrDuplicateAlias) Is(target error) bool {
+	_, ok := target.(*ErrDuplicateAlias)
+	return ok
+}
+
 // isDuplicateErr checks if a SQLite error is a UNIQUE constraint violation.
 func isDuplicateErr(err error) bool {
 	if err == nil {

--- a/backend/repo_student.go
+++ b/backend/repo_student.go
@@ -210,9 +210,9 @@ func (r *StudentRepo) BelongsToUser(ctx context.Context, studentID int64, userID
 
 // --- Alias methods ---
 
-// AddAlias adds an alias for a student. Returns ErrDuplicate if the alias
-// already exists in the same class (case-insensitive, checked across both
-// students.name and student_aliases.alias).
+// AddAlias adds an alias for a student. Returns *ErrDuplicateAlias (with the
+// conflicting student's canonical name) if the alias collides with another
+// student's name or alias in the same class (case-insensitive).
 func (r *StudentRepo) AddAlias(ctx context.Context, studentID int64, alias string) (StudentAlias, error) {
 	// Fetch the class_id for this student.
 	s, err := r.GetByID(ctx, studentID)
@@ -221,15 +221,16 @@ func (r *StudentRepo) AddAlias(ctx context.Context, studentID int64, alias strin
 	}
 
 	// Check collision with canonical names in the same class.
-	var collision int
+	var conflictName string
 	err = r.db.QueryRowContext(ctx,
-		"SELECT 1 FROM students WHERE class_id = ? AND name = ? COLLATE NOCASE AND id != ? LIMIT 1",
-		s.ClassID, alias, studentID).Scan(&collision)
+		"SELECT name FROM students WHERE class_id = ? AND name = ? COLLATE NOCASE AND id != ? LIMIT 1",
+		s.ClassID, alias, studentID).Scan(&conflictName)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return StudentAlias{}, fmt.Errorf("add alias: check name collision: %w", err)
 	}
 	if err == nil {
-		return StudentAlias{}, fmt.Errorf("add alias %q: %w", alias, ErrDuplicate)
+		// alias matches another student's canonical name
+		return StudentAlias{}, &ErrDuplicateAlias{ConflictStudentName: conflictName}
 	}
 
 	var a StudentAlias
@@ -241,7 +242,17 @@ func (r *StudentRepo) AddAlias(ctx context.Context, studentID int64, alias strin
 	).Scan(&a.ID, &a.StudentID, &a.ClassID, &a.Alias, &a.CreatedAt)
 	if err != nil {
 		if isDuplicateErr(err) {
-			return StudentAlias{}, fmt.Errorf("add alias %q: %w", alias, ErrDuplicate)
+			// alias matches an existing alias — look up who owns it (best-effort; empty name is acceptable)
+			var ownerName string
+			if scanErr := r.db.QueryRowContext(ctx, `
+				SELECT s.name FROM student_aliases sa
+				JOIN students s ON s.id = sa.student_id
+				WHERE sa.class_id = ? AND sa.alias = ? COLLATE NOCASE
+				LIMIT 1`,
+				s.ClassID, alias).Scan(&ownerName); scanErr != nil {
+				ownerName = ""
+			}
+			return StudentAlias{}, &ErrDuplicateAlias{ConflictStudentName: ownerName}
 		}
 		return StudentAlias{}, fmt.Errorf("add alias: %w", err)
 	}

--- a/backend/repo_student_alias_test.go
+++ b/backend/repo_student_alias_test.go
@@ -39,7 +39,8 @@ func TestStudentAliasRepo_AddRemoveList(t *testing.T) {
 	assert.Empty(t, aliases)
 }
 
-// TestStudentAliasRepo_DuplicateAlias checks that duplicate aliases are rejected.
+// TestStudentAliasRepo_DuplicateAlias checks that duplicate aliases are rejected
+// and the error carries the owner's name.
 func TestStudentAliasRepo_DuplicateAlias(t *testing.T) {
 	ctx, r := testDBAndRepos(t)
 
@@ -51,9 +52,11 @@ func TestStudentAliasRepo_DuplicateAlias(t *testing.T) {
 	_, err = r.students.AddAlias(ctx, s.ID, "Alex")
 	require.NoError(t, err)
 
-	// Same alias again → ErrDuplicate
+	// Same alias again → *ErrDuplicateAlias with the owner's name
 	_, err = r.students.AddAlias(ctx, s.ID, "Alex")
-	assert.True(t, errors.Is(err, ErrDuplicate), "expected ErrDuplicate, got: %v", err)
+	var dupErr *ErrDuplicateAlias
+	require.ErrorAs(t, err, &dupErr, "expected *ErrDuplicateAlias, got: %v", err)
+	assert.Equal(t, "Alexander", dupErr.ConflictStudentName)
 }
 
 // TestStudentAliasRepo_DuplicateCaseInsensitive checks that duplicate check is case-insensitive.
@@ -68,12 +71,15 @@ func TestStudentAliasRepo_DuplicateCaseInsensitive(t *testing.T) {
 	_, err = r.students.AddAlias(ctx, s.ID, "Alex")
 	require.NoError(t, err)
 
-	// Same alias, different case → ErrDuplicate
+	// Same alias, different case → *ErrDuplicateAlias
 	_, err = r.students.AddAlias(ctx, s.ID, "ALEX")
-	assert.True(t, errors.Is(err, ErrDuplicate), "expected ErrDuplicate for case variant, got: %v", err)
+	var dupErr *ErrDuplicateAlias
+	require.ErrorAs(t, err, &dupErr, "expected *ErrDuplicateAlias for case variant, got: %v", err)
+	assert.Equal(t, "Alexander", dupErr.ConflictStudentName)
 }
 
-// TestStudentAliasRepo_AliasCollidesWithName checks that an alias can't match another student's canonical name.
+// TestStudentAliasRepo_AliasCollidesWithName checks that an alias can't match another student's canonical name,
+// and that the error includes that student's name.
 func TestStudentAliasRepo_AliasCollidesWithName(t *testing.T) {
 	ctx, r := testDBAndRepos(t)
 
@@ -86,7 +92,9 @@ func TestStudentAliasRepo_AliasCollidesWithName(t *testing.T) {
 
 	// Adding "Alex" as alias for Alexander should fail — Alex is a student name in the same class
 	_, err = r.students.AddAlias(ctx, s1.ID, "Alex")
-	assert.True(t, errors.Is(err, ErrDuplicate), "alias should collide with existing student name, got: %v", err)
+	var dupErr *ErrDuplicateAlias
+	require.ErrorAs(t, err, &dupErr, "alias should collide with existing student name, got: %v", err)
+	assert.Equal(t, "Alex", dupErr.ConflictStudentName)
 }
 
 // TestFindByNameAndClass_MatchesAlias verifies that FindByNameAndClass resolves

--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -79,6 +79,37 @@
 - Don't use flat borders where a card shadow works better.
 - Don't overuse the bee/honeycomb motifs — they should feel like accents, not wallpaper.
 
+### Error Patterns
+
+Three variants for communicating errors to users:
+
+#### `<InlineError>` (inline, non-blocking)
+
+Use for errors scoped to a specific form field or panel (alias conflict, add-student duplicate, load failure, etc.).
+
+```tsx
+<InlineError title='"Katie"' onDismiss={() => setError(null)}>
+  is already used by Katherine in this class.
+</InlineError>
+```
+
+Props:
+- `title?` — bolded key value (user's input verbatim, e.g. `"Katie"`). Appears before children.
+- `severity?` — `'error'` (default) | `'warning'` | `'info'`. Controls border/bg color.
+- `onDismiss?` — if provided, renders a ✕ dismiss button.
+- `children` — explanatory message text.
+
+Severity colors:
+- `error`: `--error-red` tinted border + bg
+- `warning`: `--honey` / `--honey-dark` tinted
+- `info`: `--ink-muted` tinted
+
+**Bold-key convention:** when an error involves a specific value the user typed, put that value verbatim in `title` (quoted). Put the conflicting entity's name in the body text.
+
+#### `.flash-error` (transient sticky toast)
+
+Use for global/navigation-level errors that appear and auto-dismiss or require an action unrelated to a specific field. Rendered as a sticky banner at the bottom of a list/panel. Uses `--error-red` background. Do **not** use for field-level errors — use `<InlineError>` instead.
+
 ## Responsive
 
 ### Breakpoints

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -548,31 +548,6 @@
         "node": ">=20.19.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/frontend/src/api-types.gen.ts
+++ b/frontend/src/api-types.gen.ts
@@ -202,6 +202,19 @@ export interface ClassWithCount extends Class {
 }
 
 //////////
+// source: repo_errors.go
+
+/**
+ * ErrDuplicateAlias is returned by AddAlias when the alias collides with an
+ * existing student name or alias in the same class. ConflictStudentName holds
+ * the canonical name of the student who owns the conflicting value, so the
+ * handler can include it in the 409 response.
+ */
+export interface ErrDuplicateAlias {
+  ConflictStudentName: string;
+}
+
+//////////
 // source: repo_example.go
 
 /**

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -29,6 +29,19 @@ export type {
  */
 export type UploadJob = VoiceNoteJob
 
+/**
+ * Thrown by addAlias when the server returns a 409 alias conflict.
+ * Contains the canonical name of the student who already owns the alias.
+ */
+export class AliasConflictError extends Error {
+  conflictStudentName: string
+  constructor(message: string, conflictStudentName: string) {
+    super(message)
+    this.name = 'AliasConflictError'
+    this.conflictStudentName = conflictStudentName
+  }
+}
+
 const apiUrl = import.meta.env.VITE_API_URL
 
 // --- Class CRUD ---
@@ -500,7 +513,13 @@ export async function addAlias(
     body: JSON.stringify({ alias }),
   })
   const body = await resp.json()
-  if (!resp.ok) throw new Error(body.error || 'Failed to add alias')
+  if (!resp.ok) {
+    if (resp.status === 409) {
+      const conflictStudentName: string = body.details?.conflictStudentName ?? ''
+      throw new AliasConflictError(body.message || body.error || 'Alias already in use', conflictStudentName)
+    }
+    throw new Error(body.error || 'Failed to add alias')
+  }
   return body
 }
 

--- a/frontend/src/components/AddClassForm.tsx
+++ b/frontend/src/components/AddClassForm.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react'
 import { useAuth } from '@clerk/react'
 import { motion } from 'motion/react'
 import { createClass, listClassNames, type ClassItem } from '../api'
+import InlineError from './InlineError'
 
 interface AddClassFormProps {
   onCreated: (cls: ClassItem) => void
@@ -129,7 +130,13 @@ export default function AddClassForm({ onCreated, onCancel }: AddClassFormProps)
           )}
         </div>
       </form>
-      {error && <p className="add-form-error" data-testid="add-class-error">{error}</p>}
+      {error && (
+        <div data-testid="add-class-error">
+          <InlineError onDismiss={() => setError(null)}>
+            {error}
+          </InlineError>
+        </div>
+      )}
     </motion.div>
   )
 }

--- a/frontend/src/components/AddStudentForm.tsx
+++ b/frontend/src/components/AddStudentForm.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react'
 import { useAuth } from '@clerk/react'
 import { createStudent, type StudentItem } from '../api'
+import InlineError from './InlineError'
 
 interface AddStudentFormProps {
   classId: number
@@ -56,7 +57,13 @@ export default function AddStudentForm({ classId, onCreated }: AddStudentFormPro
           {submitting ? '…' : 'Add'}
         </button>
       </form>
-      {error && <p className="add-form-error" data-testid="add-student-error">{error}</p>}
+      {error && (
+        <div data-testid="add-student-error">
+          <InlineError onDismiss={() => setError(null)}>
+            {error}
+          </InlineError>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/InlineError.tsx
+++ b/frontend/src/components/InlineError.tsx
@@ -1,0 +1,45 @@
+import { type ReactNode } from 'react'
+
+export interface InlineErrorProps {
+  /** Bolded key value shown before children (e.g. the user's input verbatim) */
+  title?: string
+  /** Visual severity — defaults to 'error' */
+  severity?: 'error' | 'warning' | 'info'
+  /** If provided, renders a ✕ dismiss button */
+  onDismiss?: () => void
+  children: ReactNode
+}
+
+/**
+ * InlineError renders a bordered card for inline, non-blocking error / warning /
+ * info messages. Use `title` for a bolded key value (e.g. the user's input),
+ * and `children` for the explanatory message. Supply `onDismiss` to add a ✕ button.
+ */
+export default function InlineError({
+  title,
+  severity = 'error',
+  onDismiss,
+  children,
+}: InlineErrorProps) {
+  const icon = severity === 'info' ? 'ℹ' : '⚠'
+
+  return (
+    <div className={`inline-error inline-error-${severity}`} role="alert">
+      <span className="inline-error-icon" aria-hidden="true">{icon}</span>
+      <span className="inline-error-body">
+        {title && <strong className="inline-error-title">{title}</strong>}{' '}
+        {children}
+      </span>
+      {onDismiss && (
+        <button
+          className="inline-error-dismiss icon-btn"
+          onClick={onDismiss}
+          aria-label="Dismiss"
+          type="button"
+        >
+          ✕
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/StudentAliases.tsx
+++ b/frontend/src/components/StudentAliases.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { useAuth } from '@clerk/react'
 import { motion, AnimatePresence } from 'motion/react'
-import { addAlias, removeAlias, type AliasResponse } from '../api'
+import { addAlias, removeAlias, AliasConflictError, type AliasResponse } from '../api'
+import InlineError from './InlineError'
 
 interface StudentAliasesProps {
   studentId: number
@@ -17,19 +18,26 @@ export default function StudentAliases({ studentId, initialAliases }: StudentAli
   const [saving, setSaving] = useState(false)
   const [removingId, setRemovingId] = useState<number | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [conflictStudentName, setConflictStudentName] = useState<string | null>(null)
 
   async function handleAdd() {
     const trimmed = input.trim()
     if (!trimmed) return
     setSaving(true)
     setError(null)
+    setConflictStudentName(null)
     try {
       const a = await addAlias(studentId, trimmed, getToken)
       setAliases(prev => [...prev, a])
       setInput('')
       setAdding(false)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to add alias')
+      if (err instanceof AliasConflictError) {
+        setConflictStudentName(err.conflictStudentName || null)
+        setError(err.message)
+      } else {
+        setError(err instanceof Error ? err.message : 'Failed to add alias')
+      }
     } finally {
       setSaving(false)
     }
@@ -38,6 +46,7 @@ export default function StudentAliases({ studentId, initialAliases }: StudentAli
   async function handleRemove(aliasId: number) {
     setRemovingId(aliasId)
     setError(null)
+    setConflictStudentName(null)
     try {
       await removeAlias(studentId, aliasId, getToken)
       setAliases(prev => prev.filter(a => a.id !== aliasId))
@@ -50,7 +59,12 @@ export default function StudentAliases({ studentId, initialAliases }: StudentAli
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === 'Enter') { e.preventDefault(); handleAdd() }
-    if (e.key === 'Escape') { setAdding(false); setInput(''); setError(null) }
+    if (e.key === 'Escape') { setAdding(false); setInput(''); setError(null); setConflictStudentName(null) }
+  }
+
+  function handleDismissError() {
+    setError(null)
+    setConflictStudentName(null)
   }
 
   return (
@@ -102,14 +116,14 @@ export default function StudentAliases({ studentId, initialAliases }: StudentAli
             >{saving ? '…' : '✓'}</button>
             <button
               className="alias-add-cancel"
-              onClick={() => { setAdding(false); setInput(''); setError(null) }}
+              onClick={() => { setAdding(false); setInput(''); handleDismissError() }}
               aria-label="Cancel"
             >✕</button>
           </span>
         ) : (
           <button
             className="alias-add-pill"
-            onClick={() => { setAdding(true); setError(null) }}
+            onClick={() => { setAdding(true); handleDismissError() }}
             aria-label="Add alias"
           >+ alias</button>
         )}
@@ -117,15 +131,20 @@ export default function StudentAliases({ studentId, initialAliases }: StudentAli
 
       <AnimatePresence>
         {error && (
-          <motion.span
-            className="alias-error"
+          <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.15 }}
           >
-            {error}
-          </motion.span>
+            {conflictStudentName ? (
+              <InlineError title={`"${input.trim()}"`} onDismiss={handleDismissError}>
+                is already used by {conflictStudentName} in this class. Aliases must be unique per class (case-insensitive).
+              </InlineError>
+            ) : (
+              <InlineError onDismiss={handleDismissError}>{error}</InlineError>
+            )}
+          </motion.div>
         )}
       </AnimatePresence>
     </div>

--- a/frontend/src/components/StudentAliases.tsx
+++ b/frontend/src/components/StudentAliases.tsx
@@ -19,6 +19,8 @@ export default function StudentAliases({ studentId, initialAliases }: StudentAli
   const [removingId, setRemovingId] = useState<number | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [conflictStudentName, setConflictStudentName] = useState<string | null>(null)
+  // Snapshot of the alias that triggered a conflict error (not live input)
+  const [conflictAlias, setConflictAlias] = useState<string | null>(null)
 
   async function handleAdd() {
     const trimmed = input.trim()
@@ -26,6 +28,7 @@ export default function StudentAliases({ studentId, initialAliases }: StudentAli
     setSaving(true)
     setError(null)
     setConflictStudentName(null)
+    setConflictAlias(null)
     try {
       const a = await addAlias(studentId, trimmed, getToken)
       setAliases(prev => [...prev, a])
@@ -33,6 +36,7 @@ export default function StudentAliases({ studentId, initialAliases }: StudentAli
       setAdding(false)
     } catch (err) {
       if (err instanceof AliasConflictError) {
+        setConflictAlias(trimmed)
         setConflictStudentName(err.conflictStudentName || null)
         setError(err.message)
       } else {
@@ -47,6 +51,7 @@ export default function StudentAliases({ studentId, initialAliases }: StudentAli
     setRemovingId(aliasId)
     setError(null)
     setConflictStudentName(null)
+    setConflictAlias(null)
     try {
       await removeAlias(studentId, aliasId, getToken)
       setAliases(prev => prev.filter(a => a.id !== aliasId))
@@ -59,12 +64,13 @@ export default function StudentAliases({ studentId, initialAliases }: StudentAli
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === 'Enter') { e.preventDefault(); handleAdd() }
-    if (e.key === 'Escape') { setAdding(false); setInput(''); setError(null); setConflictStudentName(null) }
+    if (e.key === 'Escape') { setAdding(false); setInput(''); setError(null); setConflictStudentName(null); setConflictAlias(null) }
   }
 
   function handleDismissError() {
     setError(null)
     setConflictStudentName(null)
+    setConflictAlias(null)
   }
 
   return (
@@ -138,7 +144,7 @@ export default function StudentAliases({ studentId, initialAliases }: StudentAli
             transition={{ duration: 0.15 }}
           >
             {conflictStudentName ? (
-              <InlineError title={`"${input.trim()}"`} onDismiss={handleDismissError}>
+              <InlineError title={`"${conflictAlias}"`} onDismiss={handleDismissError}>
                 is already used by {conflictStudentName} in this class. Aliases must be unique per class (case-insensitive).
               </InlineError>
             ) : (

--- a/frontend/src/components/StudentDetail.tsx
+++ b/frontend/src/components/StudentDetail.tsx
@@ -9,6 +9,7 @@ import NotesList from './NotesList'
 import NoteEditor from './NoteEditor'
 import ReportHistory from './ReportHistory'
 import StudentAliases from './StudentAliases'
+import InlineError from './InlineError'
 
 interface StudentDetailProps {
   studentId: number
@@ -142,14 +143,12 @@ export default function StudentDetail({ studentId, studentName, className, onCol
       <AnimatePresence>
         {error && (
           <motion.div
-            className="student-detail-error"
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
             transition={{ duration: 0.2 }}
           >
-            <span>{error}</span>
-            <button className="icon-btn" onClick={() => setError(null)} aria-label="Dismiss">✕</button>
+            <InlineError onDismiss={() => setError(null)}>{error}</InlineError>
           </motion.div>
         )}
       </AnimatePresence>

--- a/frontend/src/components/StudentList.tsx
+++ b/frontend/src/components/StudentList.tsx
@@ -15,6 +15,7 @@ import {
 import AddClassForm from './AddClassForm'
 import AddStudentForm from './AddStudentForm'
 import StudentDetail from './StudentDetail'
+import InlineError from './InlineError'
 
 import { HexBullet, ChevronIcon, PencilIcon, TrashIcon } from './Icons'
 import ItemRow from './ItemRow'
@@ -424,9 +425,11 @@ export default function StudentList() {
                             </div>
                           </div>
                         ) : isFailed ? (
-                          <div className="class-students-error" data-testid={`class-error-${cls.id}`}>
-                            <span>Failed to load students.</span>
-                            <button className="btn-sm btn-secondary" onClick={() => retryLoadStudents(cls.id)}>Retry</button>
+                          <div data-testid={`class-error-${cls.id}`}>
+                            <InlineError>
+                              Failed to load students.{' '}
+                              <button className="btn-sm btn-secondary" onClick={() => retryLoadStudents(cls.id)}>Retry</button>
+                            </InlineError>
                           </div>
                         ) : (
                           <>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2546,8 +2546,61 @@ button:active,
 }
 
 /* ============================================
-   Notes List
+   Inline Error Card
    ============================================ */
+
+.inline-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  border-radius: var(--radius-sm);
+  padding: 0.6rem 0.75rem;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  margin-top: 0.4rem;
+}
+
+.inline-error-error {
+  background: rgba(197, 48, 48, 0.06);
+  border: 1px solid rgba(197, 48, 48, 0.25);
+  color: var(--error-red);
+}
+
+.inline-error-warning {
+  background: rgba(232, 163, 23, 0.08);
+  border: 1px solid rgba(232, 163, 23, 0.35);
+  color: var(--honey-dark);
+}
+
+.inline-error-info {
+  background: rgba(122, 107, 93, 0.07);
+  border: 1px solid rgba(122, 107, 93, 0.2);
+  color: var(--ink-muted);
+}
+
+.inline-error-icon {
+  flex-shrink: 0;
+  font-size: 0.85rem;
+  line-height: 1.45;
+}
+
+.inline-error-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.inline-error-title {
+  font-weight: 600;
+}
+
+.inline-error-dismiss {
+  flex-shrink: 0;
+  margin-left: 0.25rem;
+  font-size: 0.75rem;
+  opacity: 0.7;
+  padding: 0;
+  min-height: auto;
+}
 
 .notes-list {
   display: flex;


### PR DESCRIPTION
## Summary

Replaces ad-hoc red text errors with a reusable `<InlineError>` component. Closes task #21.

## Changes

**Backend**
- `apiError` now carries an optional `Details map[string]string` field (included in JSON responses)
- `AddAlias` returns `*ErrDuplicateAlias` with the conflicting student's canonical name instead of bare `ErrDuplicate`
- Alias 409 handler returns `{error: "alias_conflict", message: ..., details: {conflictStudentName: ...}}`
- New handler-level tests for the enriched 409 response; updated repo-level alias tests

**Frontend**
- New `<InlineError>` component: `title?` (bolded key), `severity?` (error/warning/info), `onDismiss?`, `children`
- `AliasConflictError` class in `api.ts`; `addAlias` throws it on 409 with `conflictStudentName`
- `StudentAliases`: conflict shows `⚠ **"Katie"** is already used by Katherine…`
- Migrated: `AddStudentForm`, `AddClassForm`, `StudentDetail`, `StudentList` all use `<InlineError>`
- `DESIGN.md`: documents error pattern (inline vs flash, severity variants, bold-key convention)
- `ARCHITECTURE.md`: documents `ErrDuplicateAlias` and enriched error envelope

## Tests

- `make lint` ✓
- `go test ./...` ✓  
- `npx vitest run` — 64/64 ✓