### PR TITLE
Decouple E2E checks from review app deployment

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -11,9 +11,14 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets: inherit
 
+  e2e:
+    name: Run E2E tests
+    uses: ./.github/workflows/e2e.yml
+    secrets: inherit
+
   deploy:
     name: Build, push, and deploy
-    needs: [test]
+    needs: [test, e2e]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,7 +38,7 @@ jobs:
           echo "VITE_CLERK_PUBLISHABLE_KEY=${{ vars.VITE_CLERK_PUBLISHABLE_KEY_TEST }}" >> frontend/.env
 
       - name: Install Playwright browsers
-        run: timeout --kill-after=30s 5m pnpm exec playwright install --with-deps chromium
+        run: timeout --kill-after=30s 10m pnpm exec playwright install --with-deps chromium
 
       - name: Run E2E tests
         run: pnpm run test:e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,17 +38,7 @@ jobs:
           echo "VITE_CLERK_PUBLISHABLE_KEY=${{ vars.VITE_CLERK_PUBLISHABLE_KEY_TEST }}" >> frontend/.env
 
       - name: Install Playwright browsers
-        run: |
-          for attempt in 1 2; do
-            if timeout --kill-after=30s 5m pnpm exec playwright install --with-deps chromium; then
-              exit 0
-            fi
-            if [ "$attempt" -eq 2 ]; then
-              echo "::error::Playwright browser installation failed after 2 attempts"
-              exit 1
-            fi
-            echo "::warning::Playwright browser installation timed out or failed; retrying"
-          done
+        run: timeout --kill-after=30s 5m pnpm exec playwright install --with-deps chromium
 
       - name: Run E2E tests
         run: pnpm run test:e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,62 @@
+name: E2E
+
+on:
+  workflow_call:
+    secrets:
+      CLERK_SECRET_KEY_TEST:
+        required: true
+
+jobs:
+  e2e:
+    name: E2E tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: backend/go.mod
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Create frontend env
+        run: |
+          echo "VITE_API_URL=http://localhost:8080/api" >> frontend/.env
+          echo "VITE_CLERK_PUBLISHABLE_KEY=${{ vars.VITE_CLERK_PUBLISHABLE_KEY_TEST }}" >> frontend/.env
+
+      - name: Install Playwright browsers
+        run: |
+          for attempt in 1 2; do
+            if timeout --kill-after=30s 5m pnpm exec playwright install --with-deps chromium; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 2 ]; then
+              echo "::error::Playwright browser installation failed after 2 attempts"
+              exit 1
+            fi
+            echo "::warning::Playwright browser installation timed out or failed; retrying"
+          done
+
+      - name: Run E2E tests
+        run: pnpm run test:e2e
+        env:
+          CI: true
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_TEST }}
+          CLERK_PUBLISHABLE_KEY: ${{ vars.VITE_CLERK_PUBLISHABLE_KEY_TEST }}
+          DB_PATH: /tmp/gradebee-test.db
+          UPLOADS_DIR: /tmp/gradebee-uploads
+          ALLOWED_ORIGIN: http://localhost:5173
+          MISTRAL_API_KEY: placeholder

--- a/.github/workflows/review-app-deploy.yml
+++ b/.github/workflows/review-app-deploy.yml
@@ -13,6 +13,11 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets: inherit
 
+  e2e:
+    name: Run E2E tests
+    uses: ./.github/workflows/e2e.yml
+    secrets: inherit
+
   deploy-review-app:
     name: Build, push, and deploy review app
     needs: [test]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,6 @@ name: Test
 
 on:
   workflow_call:
-    secrets:
-      CLERK_SECRET_KEY_TEST:
-        required: true
 
 jobs:
   test:
@@ -48,47 +45,3 @@ jobs:
 
       - name: Frontend unit tests
         run: pnpm -F frontend test --run
-
-  e2e:
-    name: E2E tests
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: backend/go.mod
-
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Set up Node
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Create frontend env
-        run: |
-          echo "VITE_API_URL=http://localhost:8080/api" >> frontend/.env
-          echo "VITE_CLERK_PUBLISHABLE_KEY=${{ vars.VITE_CLERK_PUBLISHABLE_KEY_TEST }}" >> frontend/.env
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
-
-      - name: Run E2E tests
-        run: pnpm run test:e2e
-        env:
-          CI: true
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_TEST }}
-          CLERK_PUBLISHABLE_KEY: ${{ vars.VITE_CLERK_PUBLISHABLE_KEY_TEST }}
-          DB_PATH: /tmp/gradebee-test.db
-          UPLOADS_DIR: /tmp/gradebee-uploads
-          ALLOWED_ORIGIN: http://localhost:5173
-          MISTRAL_API_KEY: placeholder

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,17 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install poppler-utils
-        run: sudo apt-get update && sudo apt-get install -y poppler-utils
+        run: |
+          for attempt in 1 2; do
+            if timeout --kill-after=30s 5m bash -c 'sudo apt-get update && sudo apt-get install -y poppler-utils'; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 2 ]; then
+              echo "::error::Poppler installation failed after 2 attempts"
+              exit 1
+            fi
+            echo "::warning::Poppler installation timed out or failed; retrying"
+          done
 
       - name: Backend unit tests
         working-directory: backend

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,17 +30,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install poppler-utils
-        run: |
-          for attempt in 1 2; do
-            if timeout --kill-after=30s 5m bash -c 'sudo apt-get update && sudo apt-get install -y poppler-utils'; then
-              exit 0
-            fi
-            if [ "$attempt" -eq 2 ]; then
-              echo "::error::Poppler installation failed after 2 attempts"
-              exit 1
-            fi
-            echo "::warning::Poppler installation timed out or failed; retrying"
-          done
+        run: timeout --kill-after=30s 5m bash -c 'sudo apt-get update && sudo apt-get install -y poppler-utils'
 
       - name: Backend unit tests
         working-directory: backend

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install poppler-utils
-        run: timeout --kill-after=30s 5m bash -c 'sudo apt-get update && sudo apt-get install -y poppler-utils'
+        run: timeout --kill-after=30s 10m bash -c 'sudo apt-get update && sudo apt-get install -y poppler-utils'
 
       - name: Backend unit tests
         working-directory: backend

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -201,6 +201,13 @@ Deployments are automated via GitHub Actions (see `.github/workflows/`):
 | `review-app-deploy.yml` | PR opened/updated | Build image → deploy to `gradebee-pr-<N>` app |
 | `review-app-teardown.yml` | PR closed | `dokku apps:destroy gradebee-pr-<N>` |
 
+Backend/frontend tests and E2E tests run independently. Review-app deployment waits only for
+backend/frontend tests, while production deployment requires both suites to pass. APT-backed
+setup steps have a 10-minute timeout to prevent a degraded package mirror from blocking a
+deployment indefinitely. If one times out, use **Re-run failed jobs** in GitHub Actions; the
+rerun starts on a fresh runner so it does not inherit package-manager locks from the failed
+attempt. An E2E timeout does not block a review app, but a backend/frontend setup timeout does.
+
 ### Required repository secrets
 
 | Secret | Description |


### PR DESCRIPTION
## Summary
- run E2E as an independent reusable workflow so review-app deployment waits only for backend/frontend tests
- keep production deployment gated on both test suites
- cap each APT-backed setup step at one ten-minute attempt; failures rerun on a fresh runner instead of retrying against locks held by orphaned privileged processes

## Test plan
- [x] Validate all GitHub Actions workflows with actionlint
- [x] Run `make lint`
- [x] Run `make test` (including 24 Playwright tests)
- [x] Run `git diff --check`