### PR TITLE
Put Add Notes above the roster on the Notes tab

### DIFF
--- a/e2e/students.spec.ts
+++ b/e2e/students.spec.ts
@@ -26,6 +26,15 @@ test.describe('Student list', () => {
 
     await page.goto('/')
     await expect(page.getByTestId('student-list')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByTestId('audio-upload')).toBeVisible()
+
+    const uploadPrecedesRoster = await page.evaluate(() => {
+      const upload = document.querySelector('[data-testid="audio-upload"]')
+      const list = document.querySelector('[data-testid="student-list"]')
+      if (!upload || !list) return false
+      return (upload.compareDocumentPosition(list) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0
+    })
+    expect(uploadPrecedesRoster).toBe(true)
 
     await expect(page.getByTestId('class-group-1')).toBeVisible()
     await expect(page.getByTestId('class-group-2')).toBeVisible()

--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -52,6 +52,16 @@ The class editor (`AddClassForm`, `StudentList`) exposes two fields with distinc
 - Dashed `--honey` border, `--comb` background, `12px` radius.
 - Drag-over: solid border + `--honey-light` bg + glow ring.
 
+### Notes tab stack
+Signed-in Notes tab (`activeTab === 'notes'` in `App.tsx`) is a single column. Do not add a Classes / Students / Record tab; `activeTab` stays `'notes' | 'reports' | 'levels'`.
+
+1. Hint banner (unchanged)
+2. Recording / Add Notes (`AudioUpload`) first
+3. Job status when any jobs exist (`JobStatus` returns `null` otherwise)
+4. Roster (`StudentList`) below — loading, fetch error, and **No Classes Yet** stay in this slot. Class **cards** start collapsed behind the summary toggle at ≤640px; **Your Classes** and **+ Add Class** stay visible. Desktop (`> 640px`) stays expanded.
+
+How It Works onboarding still describes the lifetime workflow (set up classes, then record). That is not the daily screen order.
+
 ### Empty/Info States
 - `.info-box`: centered card with subtle hex pattern overlay.
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -182,9 +182,9 @@ function SignedInContent({ activeTab, setActiveTab, setShowGuide }: {
       {activeTab === 'notes' && (
         <>
           <HintBanner storageKey="gradebee:hint:notes">Upload audio — GradeBee processes it in the background and creates notes automatically.</HintBanner>
-          <StudentList />
-          <JobStatus pollNowRef={jobPollNowRef} />
           <AudioUpload onUploadDone={() => jobPollNowRef.current?.()} />
+          <JobStatus pollNowRef={jobPollNowRef} />
+          <StudentList />
         </>
       )}
       {activeTab === 'reports' && (


### PR DESCRIPTION
## Summary
- Notes tab now shows the recording / Add Notes UI first, with the class roster on the same tab below it.
- Job status stays between record and roster (and still renders nothing when there are no jobs).
- E2E asserts document order with `compareDocumentPosition`; `frontend/DESIGN.md` documents the stack.

## Test plan
- [ ] Signed-in desktop: Notes tab shows Add Notes above Your Classes
- [ ] Desktop roster stays expanded; class cards still collapse at ≤640px
- [ ] Loading, error, and No Classes Yet still appear in the roster slot below record
- [ ] Existing e2e (`drive-setup`, `students` empty/error, `upload-jobs`) still pass