### PR TITLE
Hide Select from Drive when no Google account is linked

### DIFF
--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -57,7 +57,7 @@ The class editor (`AddClassForm`, `StudentList`) exposes two fields with distinc
 
 ### Secondary note-entry actions
 - Label **Or add existing notes** (`.existing-notes-label`) sits under the recording card.
-- `.secondary-actions` is a centered row of equal `.btn-secondary` actions: **Upload audio**, **Select from Drive**, **Enter text**.
+- `.secondary-actions` is a centered row of equal `.btn-secondary` actions: **Upload audio**, **Select from Drive** (only when the user has a linked Google account in Clerk), **Enter text**.
 - On mobile (≤640px, or `.secondary-actions--stack`), the row becomes a vertical stack with `min-height: 44px` and full width. The recording card stays first.
 
 ### File drop

--- a/frontend/src/components/AudioUpload.tsx
+++ b/frontend/src/components/AudioUpload.tsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'motion/react'
 import { uploadAudio, getGoogleToken, importFromDrive, submitTextNotes } from '../api'
 import { useDrivePicker, AUDIO_MIME_TYPES } from '../hooks/useDrivePicker'
+import { useHasLinkedGoogleAccount } from '../hooks/useHasLinkedGoogleAccount'
 import { useMediaQuery } from '../hooks/useMediaQuery'
 import { useAudioRecorder } from '../hooks/useAudioRecorder'
 
@@ -137,6 +138,7 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
   const pasteBtnRef = useRef<HTMLButtonElement>(null)
   const restorePasteFocusRef = useRef(false)
   const { openPicker } = useDrivePicker()
+  const hasLinkedGoogleAccount = useHasLinkedGoogleAccount()
   const isMobile = useMediaQuery('(max-width: 640px)')
   const recorder = useAudioRecorder()
   const [recordedFile, setRecordedFile] = useState<File | null>(null)
@@ -483,15 +485,17 @@ export default function AudioUpload({ onUploadDone }: { onUploadDone?: () => voi
                     Upload audio
                   </button>
                 )}
-                <button
-                  type="button"
-                  className="btn-secondary"
-                  onClick={handleDriveImport}
-                  data-testid="drive-import-btn"
-                >
-                  <DriveIcon />
-                  Select from Drive
-                </button>
+                {hasLinkedGoogleAccount && (
+                  <button
+                    type="button"
+                    className="btn-secondary"
+                    onClick={handleDriveImport}
+                    data-testid="drive-import-btn"
+                  >
+                    <DriveIcon />
+                    Select from Drive
+                  </button>
+                )}
                 <button
                   type="button"
                   className="btn-secondary"

--- a/frontend/src/components/__tests__/AudioUpload.test.tsx
+++ b/frontend/src/components/__tests__/AudioUpload.test.tsx
@@ -14,16 +14,23 @@ vi.mock('../../api', () => ({
   submitTextNotes: (...args: unknown[]) => mockSubmitTextNotes(...args),
 }))
 
+const mockUseMediaQuery = vi.hoisted(() => vi.fn(() => false))
+const mockUseUser = vi.hoisted(() =>
+  vi.fn(() => ({
+    user: { externalAccounts: [{ provider: 'google' }] },
+    isLoaded: true,
+  })),
+)
+
 vi.mock('@clerk/react', () => ({
   useAuth: () => ({ getToken: vi.fn().mockResolvedValue('tok') }),
+  useUser: () => mockUseUser(),
 }))
 
 vi.mock('../../hooks/useDrivePicker', () => ({
   useDrivePicker: () => ({ openPicker: vi.fn().mockResolvedValue(null) }),
   AUDIO_MIME_TYPES: 'audio/mpeg',
 }))
-
-const mockUseMediaQuery = vi.hoisted(() => vi.fn(() => false))
 
 vi.mock('../../hooks/useMediaQuery', () => ({
   useMediaQuery: () => mockUseMediaQuery(),
@@ -85,6 +92,10 @@ describe('AudioUpload', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockUseMediaQuery.mockReturnValue(false)
+    mockUseUser.mockReturnValue({
+      user: { externalAccounts: [{ provider: 'google' }] },
+      isLoaded: true,
+    })
     // jsdom doesn't implement scrollIntoView
     Element.prototype.scrollIntoView = vi.fn()
   })
@@ -549,6 +560,20 @@ describe('AudioUpload', () => {
       expect(
         within(secondaries).queryByRole('button', { name: 'Start recording' }),
       ).not.toBeInTheDocument()
+    })
+
+    it('hides Select from Drive when no Google account is linked', async () => {
+      mockUseUser.mockReturnValue({ user: { externalAccounts: [] }, isLoaded: true })
+
+      const { default: AudioUpload } = await import('../AudioUpload')
+      render(<AudioUpload />)
+
+      const secondaries = screen.getByTestId('secondary-actions')
+      expect(
+        within(secondaries).queryByRole('button', { name: 'Select from Drive' }),
+      ).not.toBeInTheDocument()
+      expect(within(secondaries).getByRole('button', { name: 'Upload audio' })).toBeInTheDocument()
+      expect(within(secondaries).getByRole('button', { name: 'Enter text' })).toBeInTheDocument()
     })
 
     it('does not show an idle drop zone or format/size advertising copy', async () => {

--- a/frontend/src/hooks/useHasLinkedGoogleAccount.ts
+++ b/frontend/src/hooks/useHasLinkedGoogleAccount.ts
@@ -1,0 +1,8 @@
+import { useUser } from '@clerk/react'
+
+/** True when the signed-in user has a linked Google external account in Clerk. */
+export function useHasLinkedGoogleAccount(): boolean {
+  const { user, isLoaded } = useUser()
+  if (!isLoaded || !user) return false
+  return user.externalAccounts.some((account) => account.provider === 'google')
+}


### PR DESCRIPTION
## Summary
- Add `useHasLinkedGoogleAccount` hook that checks Clerk `externalAccounts` for a linked Google provider.
- Conditionally render the **Select from Drive** button in `AudioUpload` only when a Google account is linked.
- Update `frontend/DESIGN.md` and add a regression test for the hidden state.

## Test plan
- [x] `make lint`
- [x] `make test`
- [ ] Manual: sign in with a Google-linked account and confirm **Select from Drive** appears
- [ ] Manual: sign in without a linked Google account and confirm the button is hidden